### PR TITLE
Missing export from the new toHaveSelectorCount

### DIFF
--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -2,10 +2,12 @@ import toHaveText from './toHaveText'
 import toEqualText from './toEqualText'
 import toHaveSelector from './toHaveSelector'
 import toEqualValue from './toEqualValue'
+import toHaveSelectorCount from './toHaveSelectorCount'
 
 export default {
   toHaveText,
   toEqualText,
   toHaveSelector,
   toEqualValue,
+  toHaveSelectorCount
 }

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -9,5 +9,5 @@ export default {
   toEqualText,
   toHaveSelector,
   toEqualValue,
-  toHaveSelectorCount
+  toHaveSelectorCount,
 }


### PR DESCRIPTION
Seems like the export for toHaveSelector count was forgotten. I was going mad trying to work out why the new matcher wasn't working in 0.3.0.