### PR TITLE
Fix getElementText util function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ await expect(page).toHaveText("#my-element", "MyValue")
 
 Or without a selector which will use the `body` element:
 
-**expect(page: [Page]).toHaveText(value: string, options?: [PageWaitForSelectorOptions](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitforselectorselector-options))**
+**expect(page: [Page]).toHaveText(value: string)**
 
 ```javascript
 await expect(page).toHaveText("Playwright")
@@ -91,7 +91,7 @@ await expect(page).toHaveText("Playwright")
 
 Or by passing a Playwright [ElementHandle]:
 
-**expect(page: [ElementHandle]).toHaveText(value: string, options?: [PageWaitForSelectorOptions](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitforselectorselector-options))**
+**expect(page: [ElementHandle]).toHaveText(value: string)**
 
 ```javascript
 const element = await page.$('#my-element');

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`expectPlaywright should be able to handle negative cases 1`] = `"'zzzBarzzz' is not included in 'zzzzz'."`;
+exports[`expectPlaywright should be able to handle negative cases return right result for page and 2 arguments 1`] = `"'zzzBarzzz' is not included in 'zzzzz'."`;
+
+exports[`expectPlaywright should be able to handle negative cases return right result for page and 4 arguments 1`] = `"Error: Timeout exceed for element '#bar'"`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,16 +30,41 @@ describe("expectPlaywright", () => {
   afterEach(async () => {
     await page.evaluate(() => document.body.innerHTML = "")
   })
-  it("should be able to handle positive cases", async () => {
-    await page.evaluate(() => {
-      document.write(`<div id="foobar">zzzBarzzz</div>`)
+  describe("should be able to handle positive cases", () => {
+    it("return right result for page and 2 arguments", async () => {
+      await page.evaluate(() => {
+        document.write(`<div id="foobar">zzzBarzzz</div>`)
+      })
+      expect(await expectPlaywright(page).toHaveText("zzzBarzzz")).toBe(true)
     })
-    expect(await expectPlaywright(page).toHaveText("zzzBarzzz")).toBe(true)
+    it("return right result for page and 3 arguments", async () => {
+      await page.evaluate(() => {
+        document.write(`<div id="bar">zzzBarzzz</div>`)
+      })
+      expect(await expectPlaywright(page).toHaveText("#bar", "zzzBarzzz")).toBe(true)
+    })
+    it("return right result for element and 2 arguments", async () => {
+      await page.evaluate(() => {
+        document.write(`<div id="foo">zzzFoozzz</div>`)
+      })
+      const elem = await page.$('#foo')
+      expect(await expectPlaywright(elem!).toHaveText("zzzFoozzz")).toBe(true)
+    })
   })
-  it("should be able to handle negative cases", async () => {
-    await page.evaluate(() => {
-      document.write(`<div id="foobar">zzzzz</div>`)
+  describe("should be able to handle negative cases", () => {
+    it("return right result for page and 2 arguments", async () => {
+      await page.evaluate(() => {
+        document.write(`<div id="foobar">zzzzz</div>`)
+      })
+      await expect(expectPlaywright(page).toHaveText("zzzBarzzz")).rejects.toThrowErrorMatchingSnapshot()
     })
-    await expect(expectPlaywright(page).toHaveText("zzzBarzzz")).rejects.toThrowErrorMatchingSnapshot()
+    it("return right result for page and 4 arguments", async () => {
+      await page.evaluate(() => {
+        document.write(`<div id="foo">zzzBarzzz</div>`)
+      })
+      await expect(expectPlaywright(page).toHaveText("#bar", "zzzBarzzz", {
+        timeout: 1* 1000
+      })).rejects.toThrowErrorMatchingSnapshot()
+    })
   })
 })

--- a/src/matchers/toHaveSelectorCount/index.ts
+++ b/src/matchers/toHaveSelectorCount/index.ts
@@ -7,9 +7,6 @@ const toHaveSelectorCount = async (page: Page, selector: string, expectedValue: 
   try {
     await page.waitForSelector(selector, {...options, state: 'attached'})
     const actualCount = (await page.$$(selector)).length
-    if (actualCount === 0) {
-      throw new Error('Element not found')
-    }
     if (actualCount === expectedValue) {
       return {
         pass: true,

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -31,36 +31,50 @@ export type InputArguments = [Page | ElementHandle, string?, (string | PageWaitF
 const lastElementHasType = (args: InputArguments, type: "string" | "object"): boolean => typeof args[args.length - 1] === type
 
 export const getElementText = async (...args: InputArguments): Promise<getElementTextReturn> => {
-  const type = detectExpectType(args[0])
-  /**
-  * Handle the following cases:
-  * - expect(page).foo("bar")
-  * - expect(element).foo("bar")
-  */
-  if (args.length === 2) {
-    if (type === ExpectTypeElementHandle) {
+  if (args.length > 1) {
+    const type = detectExpectType(args[0])
+    /**
+     * Handle the following cases:
+     * - expect(page).foo("bar")
+     * - expect(element).foo("bar")
+     */
+    if (args.length === 2) {
+      if (type === ExpectTypeElementHandle) {
+        return {
+          elementHandle: args[0] as ElementHandle,
+          expectedValue: args[1] as string
+        }
+      }
+      const page = args[0] as Page
       return {
-        elementHandle: args[0] as ElementHandle,
+        elementHandle: await page.$("body") as ElementHandle,
         expectedValue: args[1] as string
       }
     }
-    const page = args[0] as Page
-    return {
-      elementHandle: await page.$("body") as ElementHandle,
-      expectedValue: args[1] as string
-    }
-  }
-  /**
-   * Handle the following case:
-   * - expect(page).foo("#foo", "bar")
-   */
-  if (type === ExpectTypePage) {
-    const page = args[0] as Page
-    const selector = args[1] as string
-    if (args.length === 3) {
-      if (lastElementHasType(args, "string")) {
+    /**
+     * Handle the following case:
+     * - expect(page).foo("#foo", "bar")
+     */
+    if (type === ExpectTypePage) {
+      const page = args[0] as Page
+      const selector = args[1] as string
+      if (args.length === 3) {
+        if (lastElementHasType(args, "string")) {
+          try {
+            await page.waitForSelector(selector)
+          } catch (err) {
+            throw new Error(`Timeout exceed for element ${quote(selector)}`)
+          }
+          return {
+            elementHandle: await page.$(selector) as ElementHandle,
+            expectedValue: args[2] as string,
+            selector
+          }
+        }
+      }
+      if (args.length === 4 && lastElementHasType(args, "object")) {
         try {
-          await page.waitForSelector(selector)
+          await page.waitForSelector(selector, args[3] as PageWaitForSelectorOptions)
         } catch (err) {
           throw new Error(`Timeout exceed for element ${quote(selector)}`)
         }
@@ -69,18 +83,6 @@ export const getElementText = async (...args: InputArguments): Promise<getElemen
           expectedValue: args[2] as string,
           selector
         }
-      }
-    }
-    if (args.length === 4 && lastElementHasType(args, "object")) {
-      try {
-        await page.waitForSelector(selector, args[3] as PageWaitForSelectorOptions)
-      } catch (err) {
-        throw new Error(`Timeout exceed for element ${quote(selector)}`)
-      }
-      return {
-        elementHandle: await page.$(selector) as ElementHandle,
-        expectedValue: args[2] as string,
-        selector
       }
     }
   }


### PR DESCRIPTION
close #21 
I believe that we got only this cases:
- ```await expect(page).toHaveText('test')``` 2 arguments, look through `body` to contain `'test'`
- ```await expect(page).toHaveText('.selector', 'test')``` 3 arguments, wait for `.selector`, look through `.selector` to contain `'test'`
- ```await expect(page).toHaveText('.selector', 'test', options)``` 4 arguments, wait for `.selector` with passed options, look through `.selector` to contain `'test'`
- ```await expect(element).toHaveText('test')``` 2 arguments, look through `element` to contain `'test'`