### PR TITLE
Revert "Exclude test files from ts build (#48)"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,4 @@
   "include": [
     "src/**/*"
   ],
-  "exclude": [
-    "node_modules",
-    "src/**/*.test.ts"
-  ]
 }


### PR DESCRIPTION
We won't publish the files to NPM: https://unpkg.com/browse/expect-playwright@0.3.1/lib/matchers/toEqualText/

Without that it won't work in the test files: 
![image](https://user-images.githubusercontent.com/17984549/105834141-648e1e00-5fca-11eb-9e5a-8d530eea6ee4.png)


This reverts commit 29482981cdba3630786fe84f2ac258de227529d5.