### PR TITLE
Improve `toEqualUrl` and `toEqualValue` matcher messages

### DIFF
--- a/src/matchers/toEqualUrl/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toEqualUrl/__snapshots__/index.test.ts.snap
@@ -1,3 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toEqualUrl negative 1`] = `"'http://i-do-not-exist.com/2.html' expects not the current Url: 'http://i-do-not-exist.com/1.html'"`;
+exports[`toEqualUrl negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoEqualUrl[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"http://i-do-not-exist.com/2.html\\"[39m
+Received: [31m\\"http://i-do-not-exist.com/1.html\\"[39m"
+`;
+
+exports[`toEqualUrl with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoEqualUrl[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m\\"http://i-do-not-exist.com/1.html\\"[39m"
+`;

--- a/src/matchers/toEqualUrl/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toEqualUrl/__snapshots__/index.test.ts.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toEqualUrl should return false if it does not match the Url 1`] = `"'http://i-do-not-exist.com/2.html' expects not the current Url: 'http://i-do-not-exist.com/1.html'"`;
-
-exports[`toEqualUrl should return true if it matches the Url 1`] = `"'http://i-do-not-exist.com/1.html' matches the given Url."`;
+exports[`toEqualUrl negative 1`] = `"'http://i-do-not-exist.com/2.html' expects not the current Url: 'http://i-do-not-exist.com/1.html'"`;

--- a/src/matchers/toEqualUrl/index.test.ts
+++ b/src/matchers/toEqualUrl/index.test.ts
@@ -1,7 +1,12 @@
 import toEqualUrl from "."
+import { assertSnapshot } from "../tests/utils"
+
+expect.extend({ toEqualUrl })
 
 describe("toEqualUrl", () => {
-  it("should return true if it matches the Url", async () => {
+  const urlPrefix = "http://i-do-not-exist.com"
+
+  it("positive", async () => {
     await page.route("**/1.html", (route) => {
       route.fulfill({
         body: "123",
@@ -10,13 +15,11 @@ describe("toEqualUrl", () => {
         },
       })
     })
-    const myUrl = "http://i-do-not-exist.com/1.html"
+    const myUrl = `${urlPrefix}/1.html`
     await page.goto(myUrl)
-    const result = await toEqualUrl(page, myUrl)
-    expect(result.pass).toBe(true)
-    expect(result.message()).toMatchSnapshot()
+    expect(page).toEqualUrl(myUrl)
   })
-  it("should return false if it does not match the Url", async () => {
+  it("negative", async () => {
     await page.route("**/1.html", (route) => {
       route.fulfill({
         body: "123",
@@ -25,9 +28,7 @@ describe("toEqualUrl", () => {
         },
       })
     })
-    await page.goto("http://i-do-not-exist.com/1.html")
-    const result = await toEqualUrl(page, "http://i-do-not-exist.com/2.html")
-    expect(result.pass).toBe(false)
-    expect(result.message()).toMatchSnapshot()
+    await page.goto(`${urlPrefix}/1.html`)
+    await assertSnapshot(() => expect(page).toEqualUrl(`${urlPrefix}/2.html`))
   })
 })

--- a/src/matchers/toEqualUrl/index.test.ts
+++ b/src/matchers/toEqualUrl/index.test.ts
@@ -6,7 +6,7 @@ expect.extend({ toEqualUrl })
 describe("toEqualUrl", () => {
   const urlPrefix = "http://i-do-not-exist.com"
 
-  it("positive", async () => {
+  beforeAll(async () => {
     await page.route("**/1.html", (route) => {
       route.fulfill({
         body: "123",
@@ -15,20 +15,47 @@ describe("toEqualUrl", () => {
         },
       })
     })
+  })
+
+  afterEach(async () => {
+    await page.setContent("")
+  })
+
+  it("positive in frame", async () => {
+    const myUrl = `${urlPrefix}/1.html`
+    await page.setContent(`<iframe src="${myUrl}"></iframe>`)
+    const iframe = await (await page.$("iframe"))!.contentFrame()
+    expect(iframe).toEqualUrl(myUrl)
+  })
+
+  it("positive", async () => {
     const myUrl = `${urlPrefix}/1.html`
     await page.goto(myUrl)
     expect(page).toEqualUrl(myUrl)
   })
+
   it("negative", async () => {
-    await page.route("**/1.html", (route) => {
-      route.fulfill({
-        body: "123",
-        headers: {
-          "Content-Type": "text/html",
-        },
-      })
-    })
     await page.goto(`${urlPrefix}/1.html`)
     await assertSnapshot(() => expect(page).toEqualUrl(`${urlPrefix}/2.html`))
+  })
+
+  describe("with 'not' usage", () => {
+    it("positive in frame", async () => {
+      const myUrl = `${urlPrefix}/1.html`
+      await page.setContent(`<iframe src="${myUrl}"></iframe>`)
+      const iframe = await (await page.$("iframe"))!.contentFrame()
+      expect(iframe).not.toEqualUrl("foobar")
+    })
+
+    it("positive", async () => {
+      await page.goto(`${urlPrefix}/1.html`)
+      expect(page).not.toEqualUrl("foobar")
+    })
+
+    it("negative", async () => {
+      const myUrl = `${urlPrefix}/1.html`
+      await page.goto(myUrl)
+      await assertSnapshot(() => expect(page).not.toEqualUrl(myUrl))
+    })
   })
 })

--- a/src/matchers/toEqualUrl/index.ts
+++ b/src/matchers/toEqualUrl/index.ts
@@ -1,22 +1,16 @@
 import { SyncExpectationResult } from "expect/build/types"
 import { Page } from "playwright-core"
-import { getElementText, quote } from "../utils"
+import { getMessage } from "../utils"
 
-const toEqualUrl = async (
+const toEqualUrl: jest.CustomMatcher = async function (
   page: Page,
   expectedUrl: string
-): Promise<SyncExpectationResult> => {
+): Promise<SyncExpectationResult> {
   const actualUrl = page.url()
-  if (actualUrl === expectedUrl) {
-    return {
-      pass: true,
-      message: () => `${quote(expectedUrl)} matches the given Url.`,
-    }
-  }
+
   return {
-    pass: false,
-    message: () =>
-      `${quote(expectedUrl)} expects not the current Url: ${quote(actualUrl)}`,
+    pass: actualUrl === expectedUrl,
+    message: () => getMessage(this, "toEqualUrl", expectedUrl, actualUrl),
   }
 }
 

--- a/src/matchers/toEqualValue/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toEqualValue/__snapshots__/index.test.ts.snap
@@ -1,9 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toEqualValue element negative 1`] = `"'not-existing' does not equal 'bar'."`;
+exports[`toEqualValue element negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoEqualValue[2m([22m[32mexpected[39m[2m)[22m
 
-exports[`toEqualValue selector negative 1`] = `"'not-existing' does not equal 'bar' of '#foobar'."`;
+Expected: [32m\\"not-existing\\"[39m
+Received: [31m\\"bar\\"[39m"
+`;
 
-exports[`toEqualValue selector with 'not' usage negative 1`] = `"'bar' does equal 'bar'."`;
+exports[`toEqualValue selector negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoEqualValue[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"not-existing\\"[39m
+Received: [31m\\"bar\\"[39m"
+`;
+
+exports[`toEqualValue selector with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoEqualValue[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m\\"bar\\"[39m"
+`;
 
 exports[`toEqualValue timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foobar'"`;

--- a/src/matchers/toEqualValue/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toEqualValue/__snapshots__/index.test.ts.snap
@@ -4,6 +4,6 @@ exports[`toEqualValue element negative 1`] = `"'not-existing' does not equal 'ba
 
 exports[`toEqualValue selector negative 1`] = `"'not-existing' does not equal 'bar' of '#foobar'."`;
 
-exports[`toEqualValue selector positive 1`] = `"'bar' does equal 'bar'."`;
+exports[`toEqualValue selector with 'not' usage negative 1`] = `"'bar' does equal 'bar'."`;
 
 exports[`toEqualValue timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foobar'"`;

--- a/src/matchers/toEqualValue/index.ts
+++ b/src/matchers/toEqualValue/index.ts
@@ -1,9 +1,9 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { getElementText, quote, InputArguments } from "../utils"
+import { getElementText, quote, InputArguments, getMessage } from "../utils"
 
-const toEqualValue = async (
+const toEqualValue: jest.CustomMatcher = async function (
   ...args: InputArguments
-): Promise<SyncExpectationResult> => {
+): Promise<SyncExpectationResult> {
   try {
     const { elementHandle, selector, expectedValue } = await getElementText(
       ...args
@@ -12,19 +12,11 @@ const toEqualValue = async (
     const actualTextContent = await elementHandle.evaluate(
       (el) => (el as HTMLInputElement).value
     )
-    if (actualTextContent?.includes(expectedValue)) {
-      return {
-        pass: true,
-        message: () =>
-          `${quote(expectedValue)} does equal ${quote(actualTextContent)}.`,
-      }
-    }
+
     return {
-      pass: false,
+      pass: actualTextContent?.includes(expectedValue),
       message: () =>
-        `${quote(expectedValue)} does not equal ${quote(actualTextContent)}${
-          selector ? " of " + quote(selector) + "." : "."
-        }`,
+        getMessage(this, "toEqualValue", expectedValue, actualTextContent),
     }
   } catch (err) {
     return {


### PR DESCRIPTION
Relates to playwright-community/expect-playwright#69

This updates two more matchers to use the newer style matcher messages.  Here is a screenshot of the output:

## `toEqualUrl`

<img width="719" alt="Screen Shot 2021-06-04 at 9 14 40 AM" src="https://user-images.githubusercontent.com/25914066/120817985-ced64280-c517-11eb-8cbe-43846136bbe1.png">

## `toEqualValue`

<img width="719" alt="Screen Shot 2021-06-04 at 9 30 20 AM" src="https://user-images.githubusercontent.com/25914066/120817988-d0076f80-c517-11eb-9b5f-d5698027d460.png">
