### PR TITLE
Improved matcher message for selector matchers

### DIFF
--- a/src/matchers/toHaveSelector/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toHaveSelector/__snapshots__/index.test.ts.snap
@@ -1,7 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toHaveSelector negative 1`] = `"'#foobar' could not be found on the page."`;
+exports[`toHaveSelector negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoHaveSelector[2m([22m[32mexpected[39m[2m)[22m
 
-exports[`toHaveSelector timeout should throw an error after the timeout exceeds 1`] = `"'#foobar' could not be found on the page."`;
+Expected: page to have selector [32m\\"#foobar\\"[39m"
+`;
 
-exports[`toHaveSelector with 'not' usage negative 1`] = `"'#foobar' was found on the page."`;
+exports[`toHaveSelector timeout should throw an error after the timeout exceeds 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoHaveSelector[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: page to have selector [32m\\"#foobar\\"[39m"
+`;
+
+exports[`toHaveSelector with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoHaveSelector[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: page to not have selector [32m\\"#foobar\\"[39m"
+`;

--- a/src/matchers/toHaveSelector/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toHaveSelector/__snapshots__/index.test.ts.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toHaveSelector positive 1`] = `"'#foobar' was found on the page."`;
+exports[`toHaveSelector negative 1`] = `"'#foobar' could not be found on the page."`;
+
+exports[`toHaveSelector timeout should throw an error after the timeout exceeds 1`] = `"'#foobar' could not be found on the page."`;
+
+exports[`toHaveSelector with 'not' usage negative 1`] = `"'#foobar' was found on the page."`;

--- a/src/matchers/toHaveSelector/index.test.ts
+++ b/src/matchers/toHaveSelector/index.test.ts
@@ -1,6 +1,7 @@
-import { testWrapper } from "../tests/utils"
-
+import { assertSnapshot, testWrapper } from "../tests/utils"
 import toHaveSelector from "."
+
+expect.extend({ toHaveSelector })
 
 describe("toHaveSelector", () => {
   afterEach(async () => {
@@ -8,41 +9,37 @@ describe("toHaveSelector", () => {
   })
   it("positive", async () => {
     await page.setContent(`<div id="foobar">Bar</div>`)
-    const result = await toHaveSelector(page, "#foobar")
-    expect(result.pass).toBe(true)
-    expect(result.message()).toMatchSnapshot()
+    await expect(page).toHaveSelector("#foobar")
   })
   it("negative", async () => {
-    expect(
-      testWrapper(
-        await toHaveSelector(page, "#foobar", {
-          timeout: 1 * 1000,
-        })
-      )
-    ).toThrowError()
+    await assertSnapshot(() =>
+      expect(page).toHaveSelector("#foobar", { timeout: 1000 })
+    )
   })
+
+  describe("with 'not' usage", () => {
+    it("positive", async () => {
+      await expect(page).not.toHaveSelector("#foobar", { timeout: 1000 })
+    })
+
+    it("negative", async () => {
+      await page.setContent(`<div id="foobar">Bar</div>`)
+      await assertSnapshot(() => expect(page).not.toHaveSelector("#foobar"))
+    })
+  })
+
   describe("timeout", () => {
     it("positive: should be able to use a custom timeout", async () => {
       setTimeout(async () => {
         await page.setContent(`<div id="foobar">Bar</div>`)
       }, 500)
-      expect(
-        testWrapper(
-          await toHaveSelector(page, "#foobar", {
-            timeout: 1 * 1000,
-          })
-        )
-      ).toBe(true)
+      await expect(page).toHaveSelector("#foobar", { timeout: 1000 })
     })
     it("should throw an error after the timeout exceeds", async () => {
       const start = new Date().getTime()
-      expect(
-        testWrapper(
-          await toHaveSelector(page, "#foobar", {
-            timeout: 1 * 1000,
-          })
-        )
-      ).toThrowError()
+      await assertSnapshot(() =>
+        expect(page).toHaveSelector("#foobar", { timeout: 1000 })
+      )
       const duration = new Date().getTime() - start
       expect(duration).toBeLessThan(1500)
     })

--- a/src/matchers/toHaveSelector/index.ts
+++ b/src/matchers/toHaveSelector/index.ts
@@ -3,22 +3,35 @@ import { quote } from "../utils"
 import { Page } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../../global"
 
-const toHaveSelector = async (
+const toHaveSelector: jest.CustomMatcher = async function (
   page: Page,
   selector: string,
   options: PageWaitForSelectorOptions = {}
-): Promise<SyncExpectationResult> => {
-  try {
-    await page.waitForSelector(selector, options)
-    return {
-      pass: true,
-      message: () => `${quote(selector)} was found on the page.`,
-    }
-  } catch (err) {
-    return {
-      pass: false,
-      message: () => `${quote(selector)} could not be found on the page.`,
-    }
+): Promise<SyncExpectationResult> {
+  const pass = await page
+    .waitForSelector(selector, options)
+    .then(() => true)
+    .catch(() => false)
+
+  return {
+    pass: pass,
+    message: () => {
+      const not = this.isNot ? " not" : ""
+      const hint = this.utils.matcherHint(
+        "toHaveSelector",
+        undefined,
+        undefined,
+        { isNot: this.isNot, promise: this.promise }
+      )
+
+      return (
+        hint +
+        "\n\n" +
+        `Expected: page to${not} have selector ${this.utils.printExpected(
+          selector
+        )}`
+      )
+    },
   }
 }
 

--- a/src/matchers/toHaveSelectorCount/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toHaveSelectorCount/__snapshots__/index.test.ts.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toHaveSelectorCount selector negative 1`] = `"'2' does not equal '1' of '.foobar'."`;
+exports[`toHaveSelectorCount selector negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoHaveSelectorCount[2m([22m[32mexpected[39m[2m)[22m
 
-exports[`toHaveSelectorCount selector with 'not' usage negative 1`] = `"'1' does equal '1'."`;
+Expected: [32m2[39m
+Received: [31m1[39m"
+`;
+
+exports[`toHaveSelectorCount selector with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoHaveSelectorCount[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m1[39m"
+`;
 
 exports[`toHaveSelectorCount timeout should throw an error after the timeout exceeds 1`] = `"'.foobar' could not be found on the page."`;

--- a/src/matchers/toHaveSelectorCount/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toHaveSelectorCount/__snapshots__/index.test.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`toHaveSelectorCount selector negative 1`] = `"'2' does not equal '1' of '.foobar'."`;
 
-exports[`toHaveSelectorCount selector positive 1`] = `"'2' does equal '2'."`;
+exports[`toHaveSelectorCount selector with 'not' usage negative 1`] = `"'1' does equal '1'."`;
 
 exports[`toHaveSelectorCount timeout should throw an error after the timeout exceeds 1`] = `"'.foobar' could not be found on the page."`;

--- a/src/matchers/toHaveSelectorCount/index.test.ts
+++ b/src/matchers/toHaveSelectorCount/index.test.ts
@@ -1,6 +1,7 @@
-import { testWrapper } from "../tests/utils"
-
 import toHaveSelectorCount from "."
+import { assertSnapshot } from "../tests/utils"
+
+expect.extend({ toHaveSelectorCount })
 
 describe("toHaveSelectorCount", () => {
   afterEach(async () => {
@@ -11,27 +12,35 @@ describe("toHaveSelectorCount", () => {
       await page.setContent(
         `<div class="foobar"></div><div class="foobar">Bar</div>`
       )
-      const result = await toHaveSelectorCount(page, ".foobar", 2)
-      expect(result.pass).toBe(true)
-      expect(result.message()).toMatchSnapshot()
+      await expect(page).toHaveSelectorCount(".foobar", 2)
     })
     it("negative", async () => {
       await page.setContent(`<div class="foobar">Bar</div>`)
-      expect(
-        testWrapper(await toHaveSelectorCount(page, ".foobar", 2))
-      ).toThrowErrorMatchingSnapshot()
+      await assertSnapshot(() => expect(page).toHaveSelectorCount(".foobar", 2))
+    })
+
+    describe("with 'not' usage", () => {
+      it("positive", async () => {
+        await page.setContent(
+          `<div class="foobar"></div><div class="foobar">Bar</div>`
+        )
+        await expect(page).not.toHaveSelectorCount(".foobar", 1)
+      })
+
+      it("negative", async () => {
+        await page.setContent(`<div class="foobar">Bar</div>`)
+        await assertSnapshot(() =>
+          expect(page).not.toHaveSelectorCount(".foobar", 1)
+        )
+      })
     })
   })
   describe("timeout", () => {
     it("should throw an error after the timeout exceeds", async () => {
       const start = new Date().getTime()
-      expect(
-        testWrapper(
-          await toHaveSelectorCount(page, ".foobar", 1, {
-            timeout: 1 * 1000,
-          })
-        )
-      ).toThrowErrorMatchingSnapshot()
+      await assertSnapshot(() =>
+        expect(page).toHaveSelectorCount(".foobar", 1, { timeout: 1000 })
+      )
       const duration = new Date().getTime() - start
       expect(duration).toBeLessThan(1500)
     })

--- a/src/matchers/toHaveSelectorCount/index.ts
+++ b/src/matchers/toHaveSelectorCount/index.ts
@@ -1,31 +1,23 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { quote } from "../utils"
+import { getMessage, quote } from "../utils"
 import { Page } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../../global"
 
-const toHaveSelectorCount = async (
+const toHaveSelectorCount: jest.CustomMatcher = async function (
   page: Page,
   selector: string,
   expectedValue: number,
   options: PageWaitForSelectorOptions = {}
-): Promise<SyncExpectationResult> => {
+): Promise<SyncExpectationResult> {
   try {
     await page.waitForSelector(selector, { state: "attached", ...options })
     /* istanbul ignore next */
     const actualCount = await page.$$eval(selector, (el) => el.length)
-    if (actualCount === expectedValue) {
-      return {
-        pass: true,
-        message: () =>
-          `${quote(`${expectedValue}`)} does equal ${quote(`${actualCount}`)}.`,
-      }
-    }
+
     return {
-      pass: false,
+      pass: actualCount === expectedValue,
       message: () =>
-        `${quote(`${expectedValue}`)} does not equal ${quote(
-          `${actualCount}`
-        )}${selector ? " of " + quote(selector) + "." : "."}`,
+        getMessage(this, "toHaveSelectorCount", expectedValue, actualCount),
     }
   } catch (err) {
     return {

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -118,8 +118,8 @@ export const quote = (val: string | null) => (val === null ? "" : `'${val}'`)
 export const getMessage = (
   { isNot, promise, utils }: jest.MatcherContext,
   matcher: string,
-  expected: string | null,
-  received: string | null
+  expected: string | number | null,
+  received: string | number | null
 ) => {
   const message = isNot
     ? `Expected: not ${utils.printExpected(expected)}`


### PR DESCRIPTION
Relates to #69 

Updates `toHaveSelector` and `toHaveSelectorCount` matcher messages.

## `toHaveSelector`

<img width="745" alt="Screen Shot 2021-06-04 at 2 58 41 PM" src="https://user-images.githubusercontent.com/25914066/120856573-ae24e180-c545-11eb-9c30-9e90e34fc7c4.png">


## `toHaveSelectorCount`

<img width="742" alt="Screen Shot 2021-06-04 at 2 38 17 PM" src="https://user-images.githubusercontent.com/25914066/120856547-a7966a00-c545-11eb-90b5-8b3c5df36d71.png">
