### PR TITLE
Add a method to assert element visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ await expect(page).toHaveText("#foo", "my text")
 - [toEqualValue](#toEqualValue)
 - [toEqualUrl](#toEqualUrl)
 - [toHaveFocus](#toHaveFocus)
+- [toBeVisible](#toBeVisible)
 
 ### toHaveSelector
 
@@ -189,6 +190,27 @@ const element = await page.$("#my-element")
 await expect(element).toEqualValue("Playwright")
 ```
 
+### toBeVisible
+
+This function checks if a given element is visible. More information: [Visible](https://playwright.dev/docs/actionability#visible)
+
+You can do this via a selector or the element directly:
+
+**expect(page: [Page]).toBeVisible(selector: string, options?: [PageWaitForSelectorOptions](https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options))**
+
+```javascript
+await expect(page).toBeVisible("#my-element")
+```
+
+Or by passing a Playwright [ElementHandle]:
+
+**expect(element: [ElementHandle]).toBeVisible(options?: [PageWaitForSelectorOptions](https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options))**
+
+```javascript
+const element = await page.$("#my-element")
+await expect(element).toBeVisible("Playwright")
+```
+
 ## Examples
 
 ```typescript
@@ -199,6 +221,7 @@ describe("GitHub Playwright project", () => {
     const browser = await playwright.chromium.launch()
     const page = await browser.newPage()
     await page.goto("https://github.com/microsoft/playwright")
+    await expect(page).toBeVisible("#readme h1")
     await expect(page).toHaveText("#readme h1", "Playwright")
     // or also all of them via the not property
     await expect(page).not.toHaveText("this-is-no-anywhere", {

--- a/global.d.ts
+++ b/global.d.ts
@@ -61,6 +61,13 @@ export interface PlaywrightMatchers<R> {
     options?: PageWaitForSelectorOptions
   ): Promise<R>
   /**
+   * Will ensure that the element is visible.
+   */
+  toBeVisible(
+    selector?: string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
    * Will assert that N elements with the given selector are on the page and wait for it by default.
    * If its 0 elements, then it will throw since the element can't be found.
    */

--- a/src/matchers/toBeVisible/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeVisible/__snapshots__/index.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeVisible negative: handle-element : target element is not visible 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeVisible[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: element to be visible"
+`;
+
+exports[`toBeVisible negative: target element is not visible 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeVisible[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: element to be visible"
+`;
+
+exports[`toBeVisible timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foobar'"`;
+
+exports[`toBeVisible with 'not' usage negative: haandle-element: target element is visible 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeVisible[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: element to not be visible"
+`;
+
+exports[`toBeVisible with 'not' usage negative: target element is visible 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeVisible[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: element to not be visible"
+`;

--- a/src/matchers/toBeVisible/index.test.ts
+++ b/src/matchers/toBeVisible/index.test.ts
@@ -1,0 +1,68 @@
+import { assertSnapshot } from "../tests/utils"
+import toBeVisible from "."
+
+expect.extend({ toBeVisible })
+
+describe("toBeVisible", () => {
+  afterEach(async () => {
+    await page.setContent("")
+  })
+  it("positive", async () => {
+    await page.setContent(`<body><input id="foobar" style="visibility:visible"></body>`)
+    await expect(page).toBeVisible("#foobar")
+  })
+
+  it("positive: handle-element", async () => {
+    await page.setContent(`<input id="foobar" style="visibility:visible">`)
+    await expect(await page.$('#foobar')).toBeVisible()
+  })
+
+  it("negative: target element is not visible", async () => {
+    await page.setContent(`<input id="foo" style="visibility:hidden">`)
+    await assertSnapshot(async () => expect(await page.$('#foo')).toBeVisible())
+  })
+
+  it("negative: handle-element : target element is not visible", async () => {
+    await page.setContent(`<input id="foo" style="visibility:hidden">`)
+    await assertSnapshot(async () => expect(await page.$('#foo')).toBeVisible())
+  })
+
+  describe("with 'not' usage", () => {
+    it.only("positive", async () => {
+      await page.setContent(`<body><div id="bar" style="visibility:hidden"><body>`)
+      await expect(page).not.toBeVisible("div")
+    })
+
+    it("positive: handle-element", async () => {
+      await page.setContent(`<input id="foo" style="visibility:hidden">`)
+      await expect(await page.$('#foo')).not.toBeVisible()
+    })
+
+    it("negative: target element is visible", async () => {
+      await page.setContent(`<input id="foobar" style="visibility:visible">`)
+      await assertSnapshot(() => expect(page).not.toBeVisible("#foobar"))
+    })
+
+    it("negative: haandle-element: target element is visible", async () => {
+      await page.setContent(`<input id="foobar" style="visibility:visible">`)
+      await assertSnapshot(async () => expect(await page.$('#foobar')).not.toBeVisible())
+    })
+  })
+  describe("timeout", () => {
+    it("positive: should be able to use a custom timeout", async () => {
+      setTimeout(async () => {
+        await page.setContent(`<body><div id="foobar">Bar</div></body>`)
+      }, 500)
+      await expect(page).toBeVisible("#foobar")
+    })
+    it("should throw an error after the timeout exceeds", async () => {
+      const start = new Date().getTime()
+      await assertSnapshot(() =>
+        expect(page).toBeVisible("#foobar", { timeout: 1 * 1000 })
+      )
+      const duration = new Date().getTime() - start
+      expect(duration).toBeLessThan(1500)
+    })
+  })
+
+})

--- a/src/matchers/toBeVisible/index.ts
+++ b/src/matchers/toBeVisible/index.ts
@@ -1,0 +1,24 @@
+import { SyncExpectationResult } from "expect/build/types"
+import { getElement, getExpectedMessage, InputArguments } from "../utils"
+
+const toBeVisible: jest.CustomMatcher = async function (
+  ...args: InputArguments
+): Promise<SyncExpectationResult> {
+  try {
+    const { elementHandle } = await getElement(...args)
+    const actualVisibility = await elementHandle.isVisible()
+
+    return {
+      pass: actualVisibility,
+      message: () =>
+        getExpectedMessage(this, 'toBeVisible'),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toBeVisible

--- a/src/matchers/toBeVisible/index.ts
+++ b/src/matchers/toBeVisible/index.ts
@@ -1,5 +1,5 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { getElement, getExpectedMessage, InputArguments } from "../utils"
+import { getElement, getHintMessage, InputArguments } from "../utils"
 
 const toBeVisible: jest.CustomMatcher = async function (
   ...args: InputArguments
@@ -11,7 +11,7 @@ const toBeVisible: jest.CustomMatcher = async function (
     return {
       pass: actualVisibility,
       message: () =>
-        getExpectedMessage(this, 'toBeVisible'),
+      getHintMessage(this, 'toBeVisible'),
     }
   } catch (err) {
     return {

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -165,11 +165,16 @@ export const getMessage = (
     message
   )
 }
-
-export const getExpectedMessage = (
+/**
+Get the hint message for functions that validate true or false. i.e. toBeVisible
+* @param {jest.MatcherContext} matcherContext
+* @param {string} matcher
+* @return {string} Return the hit message 
+*/
+export const getHintMessage = (
   { isNot, promise, utils }: jest.MatcherContext,
   matcher: string,
-) => {
+): string => {
   const not = isNot ? " not" : ""
   const hint = utils.matcherHint(matcher, undefined, undefined, {
     isNot: isNot,


### PR DESCRIPTION
This library has great potential, but it is currently small so I found myself all the time writing different forms of assertions. This PR is the first of a series that will try to add as much as validations to web elements.

I wanted to write this method first, cause it is really simple so I will appreciate your feedback.

Notes:
* Added a `toBeVisible` validation.
* Wrote unit tests.
* Added typings
* Modified README


Note: It will be nice to have documented all the methods that we might want to add..

@mmarkelov @mxschmitt 