### PR TITLE
toMatchText | Add method to verify that an element or page text matches the given pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ await expect(page).toHaveText("#foo", "my text")
 - [toHaveSelector](#toHaveSelector)
 - [toHaveSelectorCount](#toHaveSelectorCount)
 - [toHaveText](#toHaveText)
+- [toMatchText](#toMatchText)
 - [toEqualText](#toEqualText)
 - [toEqualValue](#toEqualValue)
 - [toEqualUrl](#toEqualUrl)
@@ -128,6 +129,37 @@ Or without a selector which will use the `body` element:
 
 ```javascript
 await expect(page).toHaveText("Playwright")
+```
+
+Or by passing a Playwright [ElementHandle]:
+
+**expect(element: [ElementHandle]).toHaveText(value: string)**
+
+```javascript
+const element = await page.$("#my-element")
+await expect(element).toHaveText("Playwright")
+```
+
+### toMatchText
+
+This function checks if the `textContent` of a given element matches the provided pattern.
+
+You can do this via a selector on the whole page:
+
+**expect(page: [Page]).toMatchText(selector: string, pattern: RegExp | string, options?: [PageWaitForSelectorOptions](https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options))**
+
+```javascript
+await expect(page).toMatchText("#my-element", "MyPattern")
+await expect(page).toMatchText("#my-element", /MyPattern/)
+```
+
+Or without a selector which will use the `body` element:
+
+**expect(page: [Page]).toMatchText(pattern: RegExp | string)**
+
+```javascript
+await expect(page).toMatchText(/Playwright/)
+await expect(page).toMatchText("Playwright")
 ```
 
 Or by passing a Playwright [ElementHandle]:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ await expect(page).toHaveText("#foo", "my text")
 
 - [toHaveSelector](#toHaveSelector)
 - [toHaveSelectorCount](#toHaveSelectorCount)
-- [toHaveText](#toHaveText)
 - [toMatchText](#toMatchText)
 - [toEqualText](#toEqualText)
 - [toEqualValue](#toEqualValue)
@@ -109,35 +108,6 @@ This function checks if the count of a given selector is the same as the provide
 
 ```javascript
 await expect(page).toHaveSelectorCount(".my-element", 3)
-```
-
-### toHaveText
-
-This function checks if the `textContent` of a given element contains the provided value.
-
-You can do this via a selector on the whole page:
-
-**expect(page: [Page]).toHaveText(selector: string, value: string, options?: [PageWaitForSelectorOptions](https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options))**
-
-```javascript
-await expect(page).toHaveText("#my-element", "MyValue")
-```
-
-Or without a selector which will use the `body` element:
-
-**expect(page: [Page]).toHaveText(value: string)**
-
-```javascript
-await expect(page).toHaveText("Playwright")
-```
-
-Or by passing a Playwright [ElementHandle]:
-
-**expect(element: [ElementHandle]).toHaveText(value: string)**
-
-```javascript
-const element = await page.$("#my-element")
-await expect(element).toHaveText("Playwright")
 ```
 
 ### toMatchText

--- a/global.d.ts
+++ b/global.d.ts
@@ -24,6 +24,7 @@ interface PageWaitForSelectorOptions {
 export interface PlaywrightMatchers<R> {
   /**
    * Will check if the element's textContent on the page determined by the selector includes the given text.
+   * @deprecated Use toMatchText instead
    */
   toHaveText(
     selector: string,
@@ -32,6 +33,7 @@ export interface PlaywrightMatchers<R> {
   ): Promise<R>
   /**
    * Will check if the element's value includes the given text.
+   * @deprecated Use toMatchText instead
    */
   toHaveText(value: string, options?: PageWaitForSelectorOptions): Promise<R>
   /**

--- a/global.d.ts
+++ b/global.d.ts
@@ -45,7 +45,10 @@ export interface PlaywrightMatchers<R> {
   /**
    * Will check if the element's value matches the given pattern.
    */
-  toMatchText(pattern: RegExp | string, options?: PageWaitForSelectorOptions): Promise<R>
+  toMatchText(
+    pattern: RegExp | string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
   /**
    * Will compare the element's textContent on the page determined by the selector with the given text.
    */

--- a/global.d.ts
+++ b/global.d.ts
@@ -35,6 +35,18 @@ export interface PlaywrightMatchers<R> {
    */
   toHaveText(value: string, options?: PageWaitForSelectorOptions): Promise<R>
   /**
+   * Will check if the element's textContent on the page determined by the selector matches the given pattern.
+   */
+  toMatchText(
+    selector: string,
+    pattern: RegExp | string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
+   * Will check if the element's value matches the given pattern.
+   */
+  toMatchText(pattern: RegExp | string, options?: PageWaitForSelectorOptions): Promise<R>
+  /**
    * Will compare the element's textContent on the page determined by the selector with the given text.
    */
   toEqualText(

--- a/src/matchers/toHaveText/index.ts
+++ b/src/matchers/toHaveText/index.ts
@@ -2,9 +2,9 @@ import { SyncExpectationResult } from "expect/build/types"
 import { getElementText, getMessage, InputArguments } from "../utils"
 
 /**
-* Will check if the element's textContent on the page determined by the selector includes the given text.
-* @deprecated Use toMatchText instead
-*/
+ * Will check if the element's textContent on the page determined by the selector includes the given text.
+ * @deprecated Use toMatchText instead
+ */
 const toHaveText: jest.CustomMatcher = async function (
   ...args: InputArguments
 ): Promise<SyncExpectationResult> {

--- a/src/matchers/toHaveText/index.ts
+++ b/src/matchers/toHaveText/index.ts
@@ -1,6 +1,10 @@
 import { SyncExpectationResult } from "expect/build/types"
 import { getElementText, getMessage, InputArguments } from "../utils"
 
+/**
+* Will check if the element's textContent on the page determined by the selector includes the given text.
+* @deprecated Use toMatchText instead
+*/
 const toHaveText: jest.CustomMatcher = async function (
   ...args: InputArguments
 ): Promise<SyncExpectationResult> {

--- a/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
@@ -10,6 +10,13 @@ Received: [31m\\"zzzBarzzz\\"[39m"
 exports[`toMatchText page negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
 
+Expected: [32m/not-existing/[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;
+
+exports[`toMatchText page negative 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
 Expected: [32m\\"not-existing\\"[39m
 Received: [31m\\"zzzBarzzz\\"[39m"
 `;
@@ -21,11 +28,23 @@ Expected: [32m/[b]ar/[39m
 Received: [31m\\"zzzBarzzz\\"[39m"
 `;
 
+exports[`toMatchText selector negative with string 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"bar\\"[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;
+
 exports[`toMatchText selector timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foobar'"`;
 
 exports[`toMatchText selector with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
 
-Expected: [32m/not-existing/[39m
-Received: [31m\\"zzzBarzzz\\"[39m"
+Expected: not [32m/Bar/[39m"
+`;
+
+exports[`toMatchText selector with 'not' usage negative with string 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m\\"Bar\\"[39m"
 `;

--- a/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toMatchText element negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"not-existing\\"[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;
+
+exports[`toMatchText page negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"not-existing\\"[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;
+
+exports[`toMatchText selector negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m/[b]ar/[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;
+
+exports[`toMatchText selector timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foobar'"`;
+
+exports[`toMatchText selector with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m/not-existing/[39m
+Received: [31m\\"zzzBarzzz\\"[39m"
+`;

--- a/src/matchers/toMatchText/index.test.ts
+++ b/src/matchers/toMatchText/index.test.ts
@@ -1,0 +1,82 @@
+import toMatchText from "."
+import { assertSnapshot } from "../tests/utils"
+
+expect.extend({ toMatchText })
+
+describe("toMatchText", () => {
+  afterEach(async () => {
+    await page.setContent("")
+  })
+  describe("selector", () => {
+    it("positive frame", async () => {
+      await page.setContent(`<iframe src="https://example.com"></iframe>`)
+      const iframe = await page.$("iframe")
+      await expect(iframe!).toMatchText("h1", /.*ample Domai.*/)
+    })
+    it("positive", async () => {
+      await page.setContent(`<div id="foobar">Bar</div>`)
+      await expect(page).toMatchText("#foobar", /[B|b]ar/)
+    })
+    it("negative", async () => {
+      await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
+      await assertSnapshot(() => expect(page).toMatchText("#foobar", /[b]ar/))
+    })
+    describe("with 'not' usage", () => {
+      it("positive in frame", async () => {
+        await page.setContent(`<iframe src="https://example.com"></iframe>`)
+        const iframe = await page.$("iframe")
+        await expect(iframe!).not.toMatchText("h1", /ab+c/)
+      })
+      it("positive", async () => {
+        await page.setContent(`<div id="foobar">Bar</div>`)
+        await expect(page).not.toMatchText("#foobar", /exam.*[1|2]/)
+      })
+      it("negative", async () => {
+        await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
+        await assertSnapshot(() =>
+          expect(page).toMatchText("#foobar", /not-existing/)
+        )
+      })
+    })
+    describe("timeout", () => {
+      it("positive: should be able to use a custom timeout", async () => {
+        setTimeout(async () => {
+          await page.setContent(`<div id="foobar">Bar</div>`)
+        }, 500)
+        await expect(page).toMatchText("#foobar", /[B|b]ar/)
+      })
+      it("should throw an error after the timeout exceeds", async () => {
+        const start = new Date().getTime()
+        await assertSnapshot(() =>
+          expect(page).toMatchText("#foobar", /[B|b]ar/, { timeout: 1 * 1000 })
+        )
+        const duration = new Date().getTime() - start
+        expect(duration).toBeLessThan(1500)
+      })
+    })
+  })
+  describe("element", () => {
+    it("positive", async () => {
+      await page.setContent(`<div id="foobar">Bar</div>`)
+      const element = await page.$("#foobar")
+      expect(element).not.toBeNull()
+      await expect(element!).toMatchText("Bar")
+    })
+    it("negative", async () => {
+      await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
+      const element = await page.$("#foobar")
+      expect(element).not.toBeNull()
+      await assertSnapshot(() => expect(element!).toMatchText("not-existing"))
+    })
+  })
+  describe("page", () => {
+    it("positive", async () => {
+      await page.setContent(`<body><div>Bar</div></body>`)
+      await expect(page).toMatchText("Bar")
+    })
+    it("negative", async () => {
+      await page.setContent(`<body><div>zzzBarzzz</div></body>`)
+      await assertSnapshot(() => expect(page).toMatchText("not-existing"))
+    })
+  })
+})

--- a/src/matchers/toMatchText/index.test.ts
+++ b/src/matchers/toMatchText/index.test.ts
@@ -17,9 +17,17 @@ describe("toMatchText", () => {
       await page.setContent(`<div id="foobar">Bar</div>`)
       await expect(page).toMatchText("#foobar", /[B|b]ar/)
     })
+    it("positive with string", async () => {
+      await page.setContent(`<div id="foobar">Bar</div>`)
+      await expect(page).toMatchText("#foobar", "Bar")
+    })
     it("negative", async () => {
       await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
       await assertSnapshot(() => expect(page).toMatchText("#foobar", /[b]ar/))
+    })
+    it("negative with string", async () => {
+      await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
+      await assertSnapshot(() => expect(page).toMatchText("#foobar", "bar"))
     })
     describe("with 'not' usage", () => {
       it("positive in frame", async () => {
@@ -31,10 +39,20 @@ describe("toMatchText", () => {
         await page.setContent(`<div id="foobar">Bar</div>`)
         await expect(page).not.toMatchText("#foobar", /exam.*[1|2]/)
       })
+      it("positive with string", async () => {
+        await page.setContent(`<div id="foobar">Bar</div>`)
+        await expect(page).not.toMatchText("#foobar", "foo")
+      })
       it("negative", async () => {
+        await page.setContent(`<div class="foobar">zzzBarzzz</div>`)
+        await assertSnapshot(() =>
+          expect(page).not.toMatchText(".foobar", /Bar/)
+        )
+      })
+      it("negative with string", async () => {
         await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
         await assertSnapshot(() =>
-          expect(page).toMatchText("#foobar", /not-existing/)
+          expect(page).not.toMatchText("#foobar", "Bar")
         )
       })
     })
@@ -43,12 +61,12 @@ describe("toMatchText", () => {
         setTimeout(async () => {
           await page.setContent(`<div id="foobar">Bar</div>`)
         }, 500)
-        await expect(page).toMatchText("#foobar", /[B|b]ar/)
+        await expect(page).toMatchText("#foobar", /[B|b]ar/, { timeout: 1000 })
       })
       it("should throw an error after the timeout exceeds", async () => {
         const start = new Date().getTime()
         await assertSnapshot(() =>
-          expect(page).toMatchText("#foobar", /[B|b]ar/, { timeout: 1 * 1000 })
+          expect(page).toMatchText("#foobar", /[B|b]ar/, { timeout: 1000 })
         )
         const duration = new Date().getTime() - start
         expect(duration).toBeLessThan(1500)
@@ -57,6 +75,12 @@ describe("toMatchText", () => {
   })
   describe("element", () => {
     it("positive", async () => {
+      await page.setContent(`<div id="foobar">Bar</div>`)
+      const element = await page.$("#foobar")
+      expect(element).not.toBeNull()
+      await expect(element!).toMatchText(/Bar/)
+    })
+    it("positive with string", async () => {
       await page.setContent(`<div id="foobar">Bar</div>`)
       const element = await page.$("#foobar")
       expect(element).not.toBeNull()
@@ -73,6 +97,10 @@ describe("toMatchText", () => {
     it("positive", async () => {
       await page.setContent(`<body><div>Bar</div></body>`)
       await expect(page).toMatchText("Bar")
+    })
+    it("negative", async () => {
+      await page.setContent(`<body><div>zzzBarzzz</div></body>`)
+      await assertSnapshot(() => expect(page).toMatchText(/not-existing/))
     })
     it("negative", async () => {
       await page.setContent(`<body><div>zzzBarzzz</div></body>`)

--- a/src/matchers/toMatchText/index.ts
+++ b/src/matchers/toMatchText/index.ts
@@ -10,11 +10,10 @@ const toMatchText: jest.CustomMatcher = async function (
     const actualTextContent = await elementHandle.evaluate(
       (el) => el.textContent
     )
-    const regex = expectedValue
-    const res = actualTextContent?.match(regex) || []
+    const res = actualTextContent?.match(expectedValue)
 
     return {
-      pass: res.length > 0,
+      pass: !!res,
       message: () =>
         getMessage(this, "toMatchText", expectedValue, actualTextContent),
     }

--- a/src/matchers/toMatchText/index.ts
+++ b/src/matchers/toMatchText/index.ts
@@ -1,0 +1,29 @@
+import { SyncExpectationResult } from "expect/build/types"
+import { getElementText, getMessage, InputArguments } from "../utils"
+
+const toMatchText: jest.CustomMatcher = async function (
+  ...args: InputArguments
+): Promise<SyncExpectationResult> {
+  try {
+    const { elementHandle, expectedValue } = await getElementText(...args)
+    /* istanbul ignore next */
+    const actualTextContent = await elementHandle.evaluate(
+      (el) => el.textContent
+    )
+    const regex = expectedValue;
+    const res = actualTextContent?.match(regex) || [];
+
+    return {
+      pass: res.length > 0,
+      message: () =>
+        getMessage(this, "toMatchText", expectedValue, actualTextContent),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toMatchText

--- a/src/matchers/toMatchText/index.ts
+++ b/src/matchers/toMatchText/index.ts
@@ -10,8 +10,8 @@ const toMatchText: jest.CustomMatcher = async function (
     const actualTextContent = await elementHandle.evaluate(
       (el) => el.textContent
     )
-    const regex = expectedValue;
-    const res = actualTextContent?.match(regex) || [];
+    const regex = expectedValue
+    const res = actualTextContent?.match(regex) || []
 
     return {
       pass: res.length > 0,


### PR DESCRIPTION
This PR, adds a new method to verify that the selected element's text matches a given pattern. This is really useful to validate elements which text is dynamic for example.

`2021 Copyright` vs `2020 Copyright ` matches `202[0-9] Copyright`

I was not sure how to call this method, my options were:
 - toMatchText
 - toHaveTextMatching