### PR TITLE
README.md -  enable the matchers in Jest mode -

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ To activate it in your Jest environment you have to include it in your configura
 }
 ```
 
+```js
+// some global config e.g. a globalTypes.ts
+import { matchers } from "expect-playwright"
+expect.extend(matchers)
+// ...
+
+
 ### With [Playwright test runner](https://playwright.dev/docs/test-intro)
 
 To activate with the Playwright test runner, use `expect.extend()` in the config to add the `expect-playwright` matchers.


### PR DESCRIPTION
In order to get the expect-playwright matcher to work in Jest mode, you need to import the machers and extend the expect function.

This was missing for me? 
