### PR TITLE
chore: don't depend on playwright-core anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This library provides utility matchers for Jest in combination with [Playwright]. All of them are exposed on the `expect` object. You can use them either directly or invert them via the `.not` property like shown in a example below.
 
 ```txt
-npm install -D expect-playwright playwright-core
+npm install -D expect-playwright
 ```
 
 ## Usage

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,4 @@
-// copied into our codebase for autocompletion purposes
+// copied into our codebase for autocompletion purposes from 'playwright/types/types.d.ts' so we don't depend on it.
 interface PageWaitForSelectorOptions {
   /**
    * Defaults to `'visible'`. Can be either:
@@ -14,9 +14,8 @@ interface PageWaitForSelectorOptions {
   /**
    * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
    * using the
-   * [browserContext.setDefaultTimeout(…)](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsercontextsetdefaulttimeout)
-   * or [page.setDefaultTimeout(…)](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagesetdefaulttimeout)
-   * methods.
+   * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+   * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
    */
   timeout?: number
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,6 @@
         "prettier": "^2.3.0",
         "ts-jest": "^27.0.3",
         "typescript": "^4.3.2"
-      },
-      "peerDependencies": {
-        "playwright-core": "^1.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "start": "tsc --watch",
     "test": "jest"
   },
-  "peerDependencies": {
-    "playwright-core": "^1.12.0"
-  },
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "@types/node": "^15.12.2",

--- a/src/matchers/toHaveFocus/index.ts
+++ b/src/matchers/toHaveFocus/index.ts
@@ -1,5 +1,5 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { Page } from "playwright-core"
+import type { Page } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../../global"
 
 const enum FailureReason {

--- a/src/matchers/toHaveSelector/index.ts
+++ b/src/matchers/toHaveSelector/index.ts
@@ -1,5 +1,5 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { Page } from "playwright-core"
+import type { Page } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../../global"
 
 const toHaveSelector: jest.CustomMatcher = async function (

--- a/src/matchers/toHaveSelectorCount/index.ts
+++ b/src/matchers/toHaveSelectorCount/index.ts
@@ -1,6 +1,6 @@
 import { SyncExpectationResult } from "expect/build/types"
 import { getMessage, quote } from "../utils"
-import { Page } from "playwright-core"
+import type { Page } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../../global"
 
 const toHaveSelectorCount: jest.CustomMatcher = async function (


### PR DESCRIPTION
This PR requires a second or third eye. If I read it correctly in the code-base we don't rely on `playwright-core` during the runtime. Only when we build the project in our .ts files. I converted it to `import type` to ensure that.

Fixes #65