### PR TITLE
Update `toHaveSelector` to use `state: hidden` when `not` is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ This function waits as a maximum as the timeout exceeds for a given selector onc
 
 ```js
 await expect(page).toHaveSelector("#foobar")
-// or via not, useful to only wait 1 second instead of for the default timeout by Playwright which is 30 seconds.
-await expect(page).not.toHaveSelector("#foobar", {
-  timeout: 1 * 1000,
-})
+```
+
+When used with `not`, `toHaveSelector` will wait for the element to have the state of `hidden`.
+
+```js
+await expect(page).not.toHaveSelector("#foobar")
 ```
 
 ### toHaveFocus

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This function waits as a maximum as the timeout exceeds for a given selector onc
 await expect(page).toHaveSelector("#foobar")
 ```
 
-When used with `not`, `toHaveSelector` will wait for the element to have the state of `hidden`.
+When used with `not`, `toHaveSelector` will wait until the element is not visible or not attached. See the Playwright [waitForSelector](https://playwright.dev/docs/api/class-page#page-wait-for-selector) docs for more details.
 
 ```js
 await expect(page).not.toHaveSelector("#foobar")

--- a/src/matchers/toHaveSelector/index.test.ts
+++ b/src/matchers/toHaveSelector/index.test.ts
@@ -16,12 +16,14 @@ describe("toHaveSelector", () => {
 
   describe("with 'not' usage", () => {
     it("positive", async () => {
-      await expect(page).not.toHaveSelector("#foobar", { timeout: 1000 })
+      await expect(page).not.toHaveSelector("#foobar")
     })
 
     it("negative", async () => {
       await page.setContent(`<div id="foobar">Bar</div>`)
-      await assertSnapshot(() => expect(page).not.toHaveSelector("#foobar"))
+      await assertSnapshot(() =>
+        expect(page).not.toHaveSelector("#foobar", { timeout: 1000 })
+      )
     })
   })
 

--- a/src/matchers/toHaveSelector/index.ts
+++ b/src/matchers/toHaveSelector/index.ts
@@ -8,9 +8,12 @@ const toHaveSelector: jest.CustomMatcher = async function (
   options: PageWaitForSelectorOptions = {}
 ): Promise<SyncExpectationResult> {
   const pass = await page
-    .waitForSelector(selector, options)
-    .then(() => true)
-    .catch(() => false)
+    .waitForSelector(selector, {
+      state: this.isNot ? "hidden" : "visible",
+      ...options,
+    })
+    .then(() => !this.isNot)
+    .catch(() => this.isNot)
 
   return {
     pass: pass,


### PR DESCRIPTION
Fixes #32

Updates `toHaveSelector` to switch the state automatically to `state: 'hidden'` if used with `not`.
