### PR TITLE
Add `toBeDisabled` and `toBeEnabled` matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ await expect(page).toMatchText("#foo", "my text")
 
 ### Table of Contents
 
+- [toBeDisabled](#toBeDisabled)
+- [toBeEnabled](#toBeEnabled)
 - [toHaveSelector](#toHaveSelector)
 - [toHaveSelectorCount](#toHaveSelectorCount)
 - [toMatchText](#toMatchText)
@@ -63,6 +65,48 @@ await expect(page).toMatchText("#foo", "my text")
 - [toEqualValue](#toEqualValue)
 - [toEqualUrl](#toEqualUrl)
 - [toHaveFocus](#toHaveFocus)
+
+### toBeDisabled
+
+This function checks if a given element is disabled.
+
+You can do this via a selector on the whole page:
+
+**expect(page: [Page]).toBeDisabled(selector: string, options?: [PageWaitForSelectorOptions])**
+
+```javascript
+await expect(page).toBeDisabled("#my-element")
+```
+
+Or by passing a Playwright [ElementHandle]:
+
+**expect(element: [ElementHandle]).toBeDisabled(options?: [PageWaitForSelectorOptions])**
+
+```javascript
+const element = await page.$("#my-element")
+await expect(element).toBeDisabled()
+```
+
+### toBeEnabled
+
+This function checks if a given element is enabled.
+
+You can do this via a selector on the whole page:
+
+**expect(page: [Page]).toBeEnabled(selector: string, options?: [PageWaitForSelectorOptions])**
+
+```javascript
+await expect(page).toBeEnabled("#my-element")
+```
+
+Or by passing a Playwright [ElementHandle]:
+
+**expect(element: [ElementHandle]).toBeEnabled(options?: [PageWaitForSelectorOptions])**
+
+```javascript
+const element = await page.$("#my-element")
+await expect(element).toBeEnabled()
+```
 
 ### toHaveSelector
 
@@ -230,3 +274,4 @@ at the top of your test file or include it globally in your `tsconfig.json`.
 [elementhandle]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-elementhandle
 [page]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page
 [playwright]: https://github.com/microsoft/Playwright
+[pagewaitforselectoroptions]: https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options

--- a/global.d.ts
+++ b/global.d.ts
@@ -22,6 +22,28 @@ interface PageWaitForSelectorOptions {
 
 export interface PlaywrightMatchers<R> {
   /**
+   * Will check if the element on the page determined by the selector is disabled.
+   */
+  toBeDisabled(
+    selector: string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
+   * Will check if the element is disabled.
+   */
+  toBeDisabled(options?: PageWaitForSelectorOptions): Promise<R>
+  /**
+   * Will check if the element on the page determined by the selector is enabled.
+   */
+  toBeEnabled(
+    selector: string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
+   * Will check if the element is enabled.
+   */
+  toBeEnabled(options?: PageWaitForSelectorOptions): Promise<R>
+  /**
    * Will check if the element's textContent on the page determined by the selector includes the given text.
    * @deprecated Use toMatchText instead
    */

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,3 +1,5 @@
+import toBeDisabled from "./toBeDisabled"
+import toBeEnabled from "./toBeEnabled"
 import toHaveText from "./toHaveText"
 import toEqualText from "./toEqualText"
 import toHaveSelector from "./toHaveSelector"
@@ -8,6 +10,8 @@ import toHaveFocus from "./toHaveFocus"
 import toMatchText from "./toMatchText"
 
 export default {
+  toBeDisabled,
+  toBeEnabled,
   toHaveText,
   toEqualText,
   toHaveSelector,

--- a/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeEnabled negative: target element isn't enabled 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32mtrue[39m
+Received: [31mfalse[39m"
+`;
+
+exports[`toBeEnabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
+
+exports[`toBeEnabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
+
+exports[`toBeEnabled with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32mtrue[39m"
+`;

--- a/src/matchers/toBeDisabled/index.test.ts
+++ b/src/matchers/toBeDisabled/index.test.ts
@@ -1,0 +1,53 @@
+import { assertSnapshot } from "../tests/utils"
+
+describe("toBeEnabled", () => {
+  afterEach(async () => {
+    await page.setContent("")
+  })
+
+  it("positive", async () => {
+    await page.setContent('<button id="foo">')
+    await expect(page).toBeEnabled("#foo")
+  })
+
+  it("negative: target element isn't enabled", async () => {
+    await page.setContent('<button id="foo" disabled>')
+    await assertSnapshot(() => expect(page).toBeEnabled("#foo"))
+  })
+
+  it("negative: target element not found", async () => {
+    await page.setContent('<button id="foo">')
+    await assertSnapshot(() =>
+      expect(page).toBeEnabled("#bar", { timeout: 1000 })
+    )
+  })
+
+  describe("with 'not' usage", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      await expect(page).not.toBeEnabled("#foo")
+    })
+
+    it("negative", async () => {
+      await page.setContent('<button id="foo">')
+      await assertSnapshot(() => expect(page).not.toBeEnabled("#foo"))
+    })
+  })
+
+  describe("timeout", () => {
+    it("positive: should be able to use a custom timeout", async () => {
+      setTimeout(() => page.setContent('<button id="foo">'), 500)
+      await expect(page).toBeEnabled("#foo", { timeout: 1000 })
+    })
+
+    it("should throw an error after the timeout exceeds", async () => {
+      const start = new Date().getTime()
+      await assertSnapshot(() =>
+        expect(page).toBeEnabled("#foo", { timeout: 1000 })
+      )
+      const duration = new Date().getTime() - start
+      expect(duration).toBeGreaterThan(1000)
+      expect(duration).toBeLessThan(1500)
+    })
+  })
+})

--- a/src/matchers/toBeDisabled/index.ts
+++ b/src/matchers/toBeDisabled/index.ts
@@ -1,0 +1,27 @@
+import { SyncExpectationResult } from "expect/build/types"
+import type { Page } from "playwright-core"
+import { PageWaitForSelectorOptions } from "../../../global"
+import { getElementText, getMessage } from "../utils"
+
+const toBeDisabled: jest.CustomMatcher = async function (
+  page: Page,
+  selector: string,
+  options: PageWaitForSelectorOptions = {}
+): Promise<SyncExpectationResult> {
+  try {
+    const { elementHandle } = await getElementText(page, selector, options)
+    const isDisabled = await elementHandle.isDisabled()
+
+    return {
+      pass: isDisabled,
+      message: () => getMessage(this, "toBeDisabled", true, isDisabled),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toBeDisabled

--- a/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeEnabled negative: target element isn't enabled 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32mtrue[39m
+Received: [31mfalse[39m"
+`;
+
+exports[`toBeEnabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
+
+exports[`toBeEnabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
+
+exports[`toBeEnabled with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32mtrue[39m"
+`;

--- a/src/matchers/toBeEnabled/index.test.ts
+++ b/src/matchers/toBeEnabled/index.test.ts
@@ -1,0 +1,53 @@
+import { assertSnapshot } from "../tests/utils"
+
+describe("toBeEnabled", () => {
+  afterEach(async () => {
+    await page.setContent("")
+  })
+
+  it("positive", async () => {
+    await page.setContent('<button id="foo">')
+    await expect(page).toBeEnabled("#foo")
+  })
+
+  it("negative: target element isn't enabled", async () => {
+    await page.setContent('<button id="foo" disabled>')
+    await assertSnapshot(() => expect(page).toBeEnabled("#foo"))
+  })
+
+  it("negative: target element not found", async () => {
+    await page.setContent('<button id="foo">')
+    await assertSnapshot(() =>
+      expect(page).toBeEnabled("#bar", { timeout: 1000 })
+    )
+  })
+
+  describe("with 'not' usage", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      await expect(page).not.toBeEnabled("#foo")
+    })
+
+    it("negative", async () => {
+      await page.setContent('<button id="foo">')
+      await assertSnapshot(() => expect(page).not.toBeEnabled("#foo"))
+    })
+  })
+
+  describe("timeout", () => {
+    it("positive: should be able to use a custom timeout", async () => {
+      setTimeout(() => page.setContent('<button id="foo">'), 500)
+      await expect(page).toBeEnabled("#foo", { timeout: 1000 })
+    })
+
+    it("should throw an error after the timeout exceeds", async () => {
+      const start = new Date().getTime()
+      await assertSnapshot(() =>
+        expect(page).toBeEnabled("#foo", { timeout: 1000 })
+      )
+      const duration = new Date().getTime() - start
+      expect(duration).toBeGreaterThan(1000)
+      expect(duration).toBeLessThan(1500)
+    })
+  })
+})

--- a/src/matchers/toBeEnabled/index.ts
+++ b/src/matchers/toBeEnabled/index.ts
@@ -1,0 +1,27 @@
+import { SyncExpectationResult } from "expect/build/types"
+import type { Page } from "playwright-core"
+import { PageWaitForSelectorOptions } from "../../../global"
+import { getElementText, getMessage } from "../utils"
+
+const toBeEnabled: jest.CustomMatcher = async function (
+  page: Page,
+  selector: string,
+  options: PageWaitForSelectorOptions = {}
+): Promise<SyncExpectationResult> {
+  try {
+    const { elementHandle } = await getElementText(page, selector, options)
+    const isEnabled = await elementHandle.isEnabled()
+
+    return {
+      pass: isEnabled,
+      message: () => getMessage(this, "toBeEnabled", true, isEnabled),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toBeEnabled

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -126,8 +126,8 @@ export const quote = (val: string | null) => (val === null ? "" : `'${val}'`)
 export const getMessage = (
   { isNot, promise, utils }: jest.MatcherContext,
   matcher: string,
-  expected: string | number | null,
-  received: string | number | null
+  expected: boolean | string | number | null,
+  received: boolean | string | number | null
 ) => {
   const message = isNot
     ? `Expected: not ${utils.printExpected(expected)}`


### PR DESCRIPTION
Adds two new matchers `toBeDisabled` and `toBeEnabled`.  This takes inspiration from the playwright-expect project for these matchers.

One question I have is should we really have two matchers?  Or should we just have one and use `.not`?  Thoughts?