### PR TITLE
Add `toMatchTitle` matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ await expect(page).toMatchText("#foo", "my text")
 - [toHaveSelector](#toHaveSelector)
 - [toHaveSelectorCount](#toHaveSelectorCount)
 - [toMatchText](#toMatchText)
+- [toMatchTitle](#toMatchTitle)
 
 ### toBeDisabled
 
@@ -207,6 +208,15 @@ const element = await page.$("#my-element")
 await expect(element).toMatchText("Playwright")
 ```
 
+### toMatchTitle
+
+This function checks if the page or frame title matches the provided string or regex pattern.
+
+```javascript
+await expect(page).toMatchTitle("My app - page 1")
+await expect(page).toMatchTitle(/My app - page \d/)
+```
+
 ## Examples
 
 ```typescript
@@ -242,6 +252,4 @@ at the top of your test file or include it globally in your `tsconfig.json`.
 - [expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer)
 
 [elementhandle]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-elementhandle
-[page]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page
 [playwright]: https://github.com/microsoft/Playwright
-[pagewaitforselectoroptions]: https://playwright.dev/docs/api/class-page/#pagewaitforselectorselector-options

--- a/global.d.ts
+++ b/global.d.ts
@@ -73,6 +73,10 @@ export interface PlaywrightMatchers<R> {
     options?: PageWaitForSelectorOptions
   ): Promise<R>
   /**
+   * Will check if the page title matches a given string or regex.
+   */
+  toMatchTitle(pattern: RegExp | string): Promise<R>
+  /**
    * Will compare the element's textContent on the page determined by the selector with the given text.
    */
   toEqualText(

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,23 +1,25 @@
 import toBeDisabled from "./toBeDisabled"
 import toBeEnabled from "./toBeEnabled"
-import toHaveText from "./toHaveText"
 import toEqualText from "./toEqualText"
-import toHaveSelector from "./toHaveSelector"
-import toEqualValue from "./toEqualValue"
-import toHaveSelectorCount from "./toHaveSelectorCount"
 import toEqualUrl from "./toEqualUrl"
+import toEqualValue from "./toEqualValue"
 import toHaveFocus from "./toHaveFocus"
+import toHaveSelector from "./toHaveSelector"
+import toHaveSelectorCount from "./toHaveSelectorCount"
+import toHaveText from "./toHaveText"
 import toMatchText from "./toMatchText"
+import toMatchTitle from "./toMatchTitle"
 
 export default {
   toBeDisabled,
   toBeEnabled,
-  toHaveText,
   toEqualText,
-  toHaveSelector,
-  toEqualValue,
-  toHaveSelectorCount,
   toEqualUrl,
+  toEqualValue,
   toHaveFocus,
+  toHaveSelector,
+  toHaveSelectorCount,
+  toHaveText,
   toMatchText,
+  toMatchTitle,
 }

--- a/src/matchers/toMatchTitle/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchTitle/__snapshots__/index.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toMatchTitle with regex argument negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchTitle[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m/Bar/[39m
+Received: [31m\\"Foobar\\"[39m"
+`;
+
+exports[`toMatchTitle with regex argument with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchTitle[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m/Foo/[39m"
+`;
+
+exports[`toMatchTitle with string argument negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchTitle[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"Foo\\"[39m
+Received: [31m\\"Foobar\\"[39m"
+`;
+
+exports[`toMatchTitle with string argument with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchTitle[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m\\"Foo\\"[39m"
+`;

--- a/src/matchers/toMatchTitle/index.test.ts
+++ b/src/matchers/toMatchTitle/index.test.ts
@@ -50,4 +50,12 @@ describe("toMatchTitle", () => {
       })
     })
   })
+
+  it("should work in frames", async () => {
+    await page.setContent('<iframe src="https://example.com"></iframe>')
+    const handle = await page.$("iframe")
+    const iframe = await handle?.contentFrame()
+    await expect(handle).toMatchTitle("Example Domain")
+    await expect(iframe).toMatchTitle(/example domain/i)
+  })
 })

--- a/src/matchers/toMatchTitle/index.test.ts
+++ b/src/matchers/toMatchTitle/index.test.ts
@@ -1,0 +1,53 @@
+import { assertSnapshot } from "../tests/utils"
+
+describe("toMatchTitle", () => {
+  afterEach(() => page.setContent(""))
+
+  describe("with string argument", () => {
+    it("positive", async () => {
+      await page.setContent("<title>Foo</title>")
+      await expect(page).toMatchTitle("Foo")
+    })
+
+    it("negative", async () => {
+      await page.setContent("<title>Foobar</title>")
+      await assertSnapshot(() => expect(page).toMatchTitle("Foo"))
+    })
+
+    describe("with 'not' usage", () => {
+      it("positive", async () => {
+        await page.setContent("<title>Foobar</title>")
+        await expect(page).not.toMatchTitle("Foo")
+      })
+
+      it("negative", async () => {
+        await page.setContent("<title>Foo</title>")
+        await assertSnapshot(() => expect(page).not.toMatchTitle("Foo"))
+      })
+    })
+  })
+
+  describe("with regex argument", () => {
+    it("positive", async () => {
+      await page.setContent("<title>Foobar</title>")
+      await expect(page).toMatchTitle(/foo/i)
+    })
+
+    it("negative", async () => {
+      await page.setContent("<title>Foobar</title>")
+      await assertSnapshot(() => expect(page).toMatchTitle(/Bar/))
+    })
+
+    describe("with 'not' usage", () => {
+      it("positive", async () => {
+        await page.setContent("<title>Foo</title>")
+        await expect(page).not.toMatchTitle(/bar/)
+      })
+
+      it("negative", async () => {
+        await page.setContent("<title>Foobar</title>")
+        await assertSnapshot(() => expect(page).not.toMatchTitle(/Foo/))
+      })
+    })
+  })
+})

--- a/src/matchers/toMatchTitle/index.ts
+++ b/src/matchers/toMatchTitle/index.ts
@@ -1,0 +1,29 @@
+import { SyncExpectationResult } from "expect/build/types"
+import type { Page } from "playwright-core"
+import { getMessage } from "../utils"
+
+const toMatchTitle: jest.CustomMatcher = async function (
+  page: Page,
+  expectedValue: RegExp | string
+): Promise<SyncExpectationResult> {
+  try {
+    const actualValue = await page.title()
+    const pass =
+      typeof expectedValue === "string"
+        ? expectedValue === actualValue
+        : expectedValue.test(actualValue)
+
+    return {
+      pass,
+      message: () =>
+        getMessage(this, "toMatchTitle", expectedValue, actualValue),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toMatchTitle

--- a/src/matchers/toMatchTitle/index.ts
+++ b/src/matchers/toMatchTitle/index.ts
@@ -1,13 +1,13 @@
 import { SyncExpectationResult } from "expect/build/types"
-import type { Page } from "playwright-core"
-import { getMessage } from "../utils"
+import { ExpectInputType, getFrame, getMessage } from "../utils"
 
 const toMatchTitle: jest.CustomMatcher = async function (
-  page: Page,
+  page: ExpectInputType,
   expectedValue: RegExp | string
 ): Promise<SyncExpectationResult> {
   try {
-    const actualValue = await page.title()
+    const frame = await getFrame(page)
+    const actualValue = await frame!.title()
     const pass =
       typeof expectedValue === "string"
         ? expectedValue === actualValue

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -126,8 +126,8 @@ export const quote = (val: string | null) => (val === null ? "" : `'${val}'`)
 export const getMessage = (
   { isNot, promise, utils }: jest.MatcherContext,
   matcher: string,
-  expected: boolean | string | number | null,
-  received: boolean | string | number | null
+  expected: unknown,
+  received: unknown
 ) => {
   const message = isNot
     ? `Expected: not ${utils.printExpected(expected)}`


### PR DESCRIPTION
Adds a new matcher `toMatchTitle` which will check that a page or frame has a given title.  This PR uses the idea I suggested in #97 to be a single matcher that accepts a string for exact matching or a regex for regex based matching.  Seemed to work really easily and results in just having one matcher to deal with.

Accepts a `Page`, `Frame`, or iframe `ElementHandle`.