### PR TITLE
Deprecate `toEqualText`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,20 +185,20 @@ await expect(page).toHaveSelectorCount(".my-element", 3)
 
 ### toMatchText
 
-This function checks if the `textContent` of a given element matches the provided pattern.
+This function checks if the `textContent` of a given element matches the provided string or regex pattern.
 
 You can do this via a selector on the whole page:
 
 ```javascript
-await expect(page).toMatchText("#my-element", "MyPattern")
-await expect(page).toMatchText("#my-element", /MyPattern/)
+await expect(page).toMatchText("#my-element", "Playwright")
+await expect(page).toMatchText("#my-element", /Play.+/)
 ```
 
 Or without a selector which will use the `body` element:
 
 ```javascript
-await expect(page).toMatchText(/Playwright/)
 await expect(page).toMatchText("Playwright")
+await expect(page).toMatchText(/Play.+/)
 ```
 
 Or by passing a Playwright [ElementHandle]:
@@ -206,6 +206,7 @@ Or by passing a Playwright [ElementHandle]:
 ```javascript
 const element = await page.$("#my-element")
 await expect(element).toMatchText("Playwright")
+await expect(element).toMatchText(/Play.+/)
 ```
 
 ### toMatchTitle

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ await expect(page).toMatchText("#foo", "my text")
 
 - [toBeDisabled](#toBeDisabled)
 - [toBeEnabled](#toBeEnabled)
-- [toEqualText](#toEqualText)
 - [toEqualUrl](#toEqualUrl)
 - [toEqualValue](#toEqualValue)
 - [toHaveFocus](#toHaveFocus)
@@ -99,29 +98,6 @@ Or by passing a Playwright [ElementHandle]:
 ```javascript
 const element = await page.$("#my-element")
 await expect(element).toBeEnabled()
-```
-
-### toEqualText
-
-This function checks if the `textContent` of a given element is the same as the provided value.
-
-You can do this via a selector on the whole page:
-
-```javascript
-await expect(page).toEqualText("#my-element", "Playwright")
-```
-
-Or without a selector which will use the `body` element:
-
-```javascript
-await expect(page).toEqualText("Playwright")
-```
-
-Or by passing a Playwright [ElementHandle]:
-
-```javascript
-const element = await page.$("#my-element")
-await expect(element).toEqualText("Playwright")
 ```
 
 ### toEqualUrl

--- a/global.d.ts
+++ b/global.d.ts
@@ -78,6 +78,7 @@ export interface PlaywrightMatchers<R> {
   toMatchTitle(pattern: RegExp | string): Promise<R>
   /**
    * Will compare the element's textContent on the page determined by the selector with the given text.
+   * @deprecated - Use `toMatchText`
    */
   toEqualText(
     selector: string,
@@ -86,6 +87,7 @@ export interface PlaywrightMatchers<R> {
   ): Promise<R>
   /**
    * Will compare the element's textContent by the given text.
+   * @deprecated - Use `toMatchText`
    */
   toEqualText(value: string, options?: PageWaitForSelectorOptions): Promise<R>
   /**

--- a/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toBeEnabled negative: target element isn't enabled 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+exports[`toBeDisabled negative: target element isn't enabled 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeDisabled[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
 `;
 
-exports[`toBeEnabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
+exports[`toBeDisabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
 
-exports[`toBeEnabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
+exports[`toBeDisabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
 
-exports[`toBeEnabled with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+exports[`toBeDisabled with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeDisabled[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: not [32mtrue[39m"
 `;

--- a/src/matchers/toBeDisabled/index.test.ts
+++ b/src/matchers/toBeDisabled/index.test.ts
@@ -1,49 +1,49 @@
 import { assertSnapshot } from "../tests/utils"
 
-describe("toBeEnabled", () => {
+describe("toBeDisabled", () => {
   afterEach(async () => {
     await page.setContent("")
   })
 
   it("positive", async () => {
-    await page.setContent('<button id="foo">')
-    await expect(page).toBeEnabled("#foo")
+    await page.setContent('<button id="foo" disabled>')
+    await expect(page).toBeDisabled("#foo")
   })
 
   it("negative: target element isn't enabled", async () => {
-    await page.setContent('<button id="foo" disabled>')
-    await assertSnapshot(() => expect(page).toBeEnabled("#foo"))
+    await page.setContent('<button id="foo">')
+    await assertSnapshot(() => expect(page).toBeDisabled("#foo"))
   })
 
   it("negative: target element not found", async () => {
     await page.setContent('<button id="foo">')
     await assertSnapshot(() =>
-      expect(page).toBeEnabled("#bar", { timeout: 1000 })
+      expect(page).toBeDisabled("#bar", { timeout: 1000 })
     )
   })
 
   describe("with 'not' usage", () => {
     it("positive", async () => {
-      await page.setContent('<button id="foo" disabled>')
-      await expect(page).not.toBeEnabled("#foo")
+      await page.setContent('<button id="foo">')
+      await expect(page).not.toBeDisabled("#foo")
     })
 
     it("negative", async () => {
-      await page.setContent('<button id="foo">')
-      await assertSnapshot(() => expect(page).not.toBeEnabled("#foo"))
+      await page.setContent('<button id="foo" disabled>')
+      await assertSnapshot(() => expect(page).not.toBeDisabled("#foo"))
     })
   })
 
   describe("timeout", () => {
     it("positive: should be able to use a custom timeout", async () => {
-      setTimeout(() => page.setContent('<button id="foo">'), 500)
-      await expect(page).toBeEnabled("#foo", { timeout: 1000 })
+      setTimeout(() => page.setContent('<button id="foo" disabled>'), 500)
+      await expect(page).toBeDisabled("#foo", { timeout: 1000 })
     })
 
     it("should throw an error after the timeout exceeds", async () => {
       const start = new Date().getTime()
       await assertSnapshot(() =>
-        expect(page).toBeEnabled("#foo", { timeout: 1000 })
+        expect(page).toBeDisabled("#foo", { timeout: 1000 })
       )
       const duration = new Date().getTime() - start
       expect(duration).toBeGreaterThan(1000)

--- a/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchText/__snapshots__/index.test.ts.snap
@@ -48,5 +48,5 @@ Expected: not [32m/Bar/[39m"
 exports[`toMatchText selector with 'not' usage negative with string 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchText[2m([22m[32mexpected[39m[2m)[22m
 
-Expected: not [32m\\"Bar\\"[39m"
+Expected: not [32m\\"Foo\\"[39m"
 `;

--- a/src/matchers/toMatchText/index.test.ts
+++ b/src/matchers/toMatchText/index.test.ts
@@ -51,9 +51,9 @@ describe("toMatchText", () => {
         )
       })
       it("negative with string", async () => {
-        await page.setContent(`<div id="foobar">zzzBarzzz</div>`)
+        await page.setContent(`<div id="foobar">Foo</div>`)
         await assertSnapshot(() =>
-          expect(page).not.toMatchText("#foobar", "Bar")
+          expect(page).not.toMatchText("#foobar", "Foo")
         )
       })
     })

--- a/src/matchers/toMatchText/index.ts
+++ b/src/matchers/toMatchText/index.ts
@@ -1,5 +1,10 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { getElementText, getMessage, InputArguments } from "../utils"
+import {
+  compareText,
+  getElementText,
+  getMessage,
+  InputArguments,
+} from "../utils"
 
 const toMatchText: jest.CustomMatcher = async function (
   ...args: InputArguments
@@ -7,15 +12,13 @@ const toMatchText: jest.CustomMatcher = async function (
   try {
     const { elementHandle, expectedValue } = await getElementText(...args)
     /* istanbul ignore next */
-    const actualTextContent = await elementHandle.evaluate(
-      (el) => el.textContent
-    )
-    const res = actualTextContent?.match(expectedValue)
+    const actualValue = await elementHandle.evaluate((el) => el.textContent)
+    const pass = compareText(expectedValue, actualValue)
 
     return {
-      pass: !!res,
+      pass,
       message: () =>
-        getMessage(this, "toMatchText", expectedValue, actualTextContent),
+        getMessage(this, "toMatchText", expectedValue, actualValue),
     }
   } catch (err) {
     return {

--- a/src/matchers/toMatchTitle/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchTitle/__snapshots__/index.test.ts.snap
@@ -17,7 +17,7 @@ exports[`toMatchTitle with string argument negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchTitle[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: [32m\\"Foo\\"[39m
-Received: [31m\\"Foobar\\"[39m"
+Received: [31m\\"Foo[7mbar[27m\\"[39m"
 `;
 
 exports[`toMatchTitle with string argument with 'not' usage negative 1`] = `

--- a/src/matchers/toMatchTitle/index.ts
+++ b/src/matchers/toMatchTitle/index.ts
@@ -1,5 +1,5 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { ExpectInputType, getFrame, getMessage } from "../utils"
+import { compareText, ExpectInputType, getFrame, getMessage } from "../utils"
 
 const toMatchTitle: jest.CustomMatcher = async function (
   page: ExpectInputType,
@@ -8,10 +8,7 @@ const toMatchTitle: jest.CustomMatcher = async function (
   try {
     const frame = await getFrame(page)
     const actualValue = await frame!.title()
-    const pass =
-      typeof expectedValue === "string"
-        ? expectedValue === actualValue
-        : expectedValue.test(actualValue)
+    const pass = compareText(expectedValue, actualValue)
 
     return {
       pass,

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -145,3 +145,12 @@ export const getMessage = (
     message
   )
 }
+
+export const compareText = (
+  expectedValue: string | RegExp,
+  actualValue: string | null
+) => {
+  return typeof expectedValue === "string"
+    ? expectedValue === actualValue
+    : expectedValue.test(actualValue ?? "")
+}


### PR DESCRIPTION
Per #97 and #98 this PR deprecates `toEqualText` in favor of `toMatchText` which now supports both exact string matching when a string is passed or regex matching when a regex is passed.