### PR TITLE
Add `toMatchAttribute` matcher

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -74,7 +74,7 @@ export interface PlaywrightMatchers<R> {
   toMatchAttribute(
     selector: string,
     attribute: string,
-    value: string,
+    value: RegExp | string,
     options?: PageWaitForSelectorOptions
   ): Promise<R>
   /**
@@ -82,7 +82,7 @@ export interface PlaywrightMatchers<R> {
    */
   toMatchAttribute(
     attribute: string,
-    value: string,
+    value: RegExp | string,
     options?: PageWaitForSelectorOptions
   ): Promise<R>
   /**

--- a/global.d.ts
+++ b/global.d.ts
@@ -69,6 +69,23 @@ export interface PlaywrightMatchers<R> {
    */
   toHaveText(value: string, options?: PageWaitForSelectorOptions): Promise<R>
   /**
+   * Will check if an element's attribute on the page determined by the selector matches the given pattern.
+   */
+  toMatchAttribute(
+    selector: string,
+    attribute: string,
+    value: string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
+   * Will check if an element's attribute matches the given pattern.
+   */
+  toMatchAttribute(
+    attribute: string,
+    value: string,
+    options?: PageWaitForSelectorOptions
+  ): Promise<R>
+  /**
    * Will check if the element's textContent on the page determined by the selector matches the given pattern.
    */
   toMatchText(

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -8,6 +8,7 @@ import toHaveFocus from "./toHaveFocus"
 import toHaveSelector from "./toHaveSelector"
 import toHaveSelectorCount from "./toHaveSelectorCount"
 import toHaveText from "./toHaveText"
+import toMatchAttribute from "./toMatchAttribute"
 import toMatchText from "./toMatchText"
 import toMatchTitle from "./toMatchTitle"
 
@@ -22,6 +23,7 @@ export default {
   toHaveSelector,
   toHaveSelectorCount,
   toHaveText,
+  toMatchAttribute,
   toMatchText,
   toMatchTitle,
 }

--- a/src/matchers/toBeChecked/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeChecked/__snapshots__/index.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeChecked element negative: target element isn't checked 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeChecked[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeChecked[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
 `;
 
 exports[`toBeChecked selector negative: target element isn't checked 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeChecked[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeChecked[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
@@ -19,7 +19,7 @@ exports[`toBeChecked selector negative: target element not found 1`] = `"Error: 
 exports[`toBeChecked timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element 'input'"`;
 
 exports[`toBeChecked with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeChecked[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeChecked[2m()[22m
 
 Expected: not [32mtrue[39m"
 `;

--- a/src/matchers/toBeChecked/index.ts
+++ b/src/matchers/toBeChecked/index.ts
@@ -10,7 +10,7 @@ const toBeChecked: jest.CustomMatcher = async function (
 
     return {
       pass: isChecked,
-      message: () => getMessage(this, "toBeChecked", true, isChecked),
+      message: () => getMessage(this, "toBeChecked", true, isChecked, ""),
     }
   } catch (err) {
     return {

--- a/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeDisabled negative: target element isn't enabled 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeDisabled[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeDisabled[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
@@ -12,7 +12,7 @@ exports[`toBeDisabled negative: target element not found 1`] = `"Error: Timeout 
 exports[`toBeDisabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
 
 exports[`toBeDisabled with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeDisabled[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeDisabled[2m()[22m
 
 Expected: not [32mtrue[39m"
 `;

--- a/src/matchers/toBeDisabled/index.ts
+++ b/src/matchers/toBeDisabled/index.ts
@@ -10,7 +10,7 @@ const toBeDisabled: jest.CustomMatcher = async function (
 
     return {
       pass: isDisabled,
-      message: () => getMessage(this, "toBeDisabled", true, isDisabled),
+      message: () => getMessage(this, "toBeDisabled", true, isDisabled, ""),
     }
   } catch (err) {
     return {

--- a/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeEnabled negative: target element isn't enabled 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
@@ -12,7 +12,7 @@ exports[`toBeEnabled negative: target element not found 1`] = `"Error: Timeout e
 exports[`toBeEnabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
 
 exports[`toBeEnabled with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeEnabled[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoBeEnabled[2m()[22m
 
 Expected: not [32mtrue[39m"
 `;

--- a/src/matchers/toBeEnabled/index.ts
+++ b/src/matchers/toBeEnabled/index.ts
@@ -10,7 +10,7 @@ const toBeEnabled: jest.CustomMatcher = async function (
 
     return {
       pass: isEnabled,
-      message: () => getMessage(this, "toBeEnabled", true, isEnabled),
+      message: () => getMessage(this, "toBeEnabled", true, isEnabled, ""),
     }
   } catch (err) {
     return {

--- a/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toMatchAttribute element negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
+Received: [31m\\"http://google.com\\"[39m"
+`;
+
+exports[`toMatchAttribute selector negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
+Received: [31m\\"http://google.com\\"[39m"
+`;
+
+exports[`toMatchAttribute selector negative: target element not found 1`] = `"Error: Timeout exceed for element 'a'"`;
+
+exports[`toMatchAttribute timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element 'a'"`;
+
+exports[`toMatchAttribute with 'not' usage negative 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: not [32m\\"http://google.com\\"[39m"
+`;

--- a/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
@@ -7,10 +7,24 @@ Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
 Received: [31m\\"http://google.com\\"[39m"
 `;
 
+exports[`toMatchAttribute element negative 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m/\\\\.org$/[39m
+Received: [31m\\"http://google.com\\"[39m"
+`;
+
 exports[`toMatchAttribute selector negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
+Received: [31m\\"http://google.com\\"[39m"
+`;
+
+exports[`toMatchAttribute selector negative 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+
+Expected: [32m/\\\\.org$/[39m
 Received: [31m\\"http://google.com\\"[39m"
 `;
 

--- a/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toMatchAttribute element negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32m\\"href\\", expected[39m[2m)[22m
 
 Expected: [32m\\"https://[7mwww.[27mgoogle.com\\"[39m
 Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute element negative 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32m\\"href\\", expected[39m[2m)[22m
 
 Expected: [32m/\\\\.org$/[39m
 Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute selector negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32m\\"href\\", expected[39m[2m)[22m
 
 Expected: [32m\\"https://[7mwww.[27mgoogle.com\\"[39m
 Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute selector negative 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32m\\"href\\", expected[39m[2m)[22m
 
 Expected: [32m/\\\\.org$/[39m
 Received: [31m\\"https://google.com\\"[39m"
@@ -33,7 +33,7 @@ exports[`toMatchAttribute selector negative: target element not found 1`] = `"Er
 exports[`toMatchAttribute timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element 'a'"`;
 
 exports[`toMatchAttribute with 'not' usage negative 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
+"[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchAttribute[2m([22m[32m\\"href\\", expected[39m[2m)[22m
 
 Expected: not [32m\\"https://google.com\\"[39m"
 `;

--- a/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toMatchAttribute/__snapshots__/index.test.ts.snap
@@ -3,29 +3,29 @@
 exports[`toMatchAttribute element negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
-Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
-Received: [31m\\"http://google.com\\"[39m"
+Expected: [32m\\"https://[7mwww.[27mgoogle.com\\"[39m
+Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute element negative 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: [32m/\\\\.org$/[39m
-Received: [31m\\"http://google.com\\"[39m"
+Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute selector negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
-Expected: [32m\\"http[7ms[27m://[7mwww.[27mgoogle.com\\"[39m
-Received: [31m\\"http://google.com\\"[39m"
+Expected: [32m\\"https://[7mwww.[27mgoogle.com\\"[39m
+Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute selector negative 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
 Expected: [32m/\\\\.org$/[39m
-Received: [31m\\"http://google.com\\"[39m"
+Received: [31m\\"https://google.com\\"[39m"
 `;
 
 exports[`toMatchAttribute selector negative: target element not found 1`] = `"Error: Timeout exceed for element 'a'"`;
@@ -35,5 +35,5 @@ exports[`toMatchAttribute timeout should throw an error after the timeout exceed
 exports[`toMatchAttribute with 'not' usage negative 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mnot[2m.[22mtoMatchAttribute[2m([22m[32mexpected[39m[2m)[22m
 
-Expected: not [32m\\"http://google.com\\"[39m"
+Expected: not [32m\\"https://google.com\\"[39m"
 `;

--- a/src/matchers/toMatchAttribute/index.test.ts
+++ b/src/matchers/toMatchAttribute/index.test.ts
@@ -1,0 +1,71 @@
+import { assertSnapshot } from "../tests/utils"
+
+describe("toMatchAttribute", () => {
+  afterEach(() => page.setContent(""))
+
+  describe("selector", () => {
+    it("positive", async () => {
+      await page.setContent('<a href="http://google.com">Hi</a>')
+      await expect(page).toMatchAttribute("a", "href", "http://google.com")
+    })
+
+    it("negative", async () => {
+      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await assertSnapshot(() =>
+        expect(page).toMatchAttribute("a", "href", "https://www.google.com")
+      )
+    })
+
+    it("negative: target element not found", async () => {
+      await assertSnapshot(() =>
+        expect(page).toMatchAttribute("a", "foo", "bar", { timeout: 1000 })
+      )
+    })
+  })
+
+  describe("element", () => {
+    it("positive", async () => {
+      await page.setContent('<a href="http://google.com">>Hi</a>')
+      const anchor = await page.$("a")
+      await expect(anchor).toMatchAttribute("href", "http://google.com")
+    })
+
+    it("negative", async () => {
+      await page.setContent('<a href="http://google.com">>Hi</a>')
+      const anchor = await page.$("a")
+      await assertSnapshot(() =>
+        expect(anchor).toMatchAttribute("href", "https://www.google.com")
+      )
+    })
+  })
+
+  describe("with 'not' usage", () => {
+    it("positive", async () => {
+      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await expect(page).not.toMatchAttribute(
+        "a",
+        "href",
+        "https://www.google.com"
+      )
+    })
+
+    it("negative", async () => {
+      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await assertSnapshot(() =>
+        expect(page).not.toMatchAttribute("a", "href", "http://google.com")
+      )
+    })
+  })
+
+  describe("timeout", () => {
+    it("should throw an error after the timeout exceeds", async () => {
+      const start = new Date().getTime()
+      await assertSnapshot(() =>
+        expect(page).toMatchAttribute("a", "foo", "bar", { timeout: 1000 })
+      )
+      const duration = new Date().getTime() - start
+      expect(duration).toBeGreaterThan(1000)
+      expect(duration).toBeLessThan(1500)
+    })
+  })
+})

--- a/src/matchers/toMatchAttribute/index.test.ts
+++ b/src/matchers/toMatchAttribute/index.test.ts
@@ -2,27 +2,28 @@ import { assertSnapshot } from "../tests/utils"
 
 const url = "https://google.com"
 const longUrl = "https://www.google.com"
+const frameUrl = "https://www.iana.org/domains/example"
 
 describe("toMatchAttribute", () => {
   afterEach(() => page.setContent(""))
 
   describe("selector", () => {
     it("positive", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       await expect(page).toMatchAttribute("a", "href", url)
       await expect(page).toMatchAttribute("a", "href", /\.com$/)
     })
 
     it("positive in frame", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<iframe src="http://example.com">')
       const handle = await page.$("iframe")
       const frame = handle?.contentFrame()
-      await expect(handle).toMatchAttribute("a", "href", url)
-      await expect(frame).toMatchAttribute("a", "href", /\.com$/)
+      await expect(handle).toMatchAttribute("a", "href", frameUrl)
+      await expect(frame).toMatchAttribute("a", "href", /example$/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       await assertSnapshot(() =>
         expect(page).toMatchAttribute("a", "href", longUrl)
       )
@@ -40,14 +41,14 @@ describe("toMatchAttribute", () => {
 
   describe("element", () => {
     it("positive", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       const anchor = await page.$("a")
-      await expect(anchor).toMatchAttribute("href", "http://google.com")
+      await expect(anchor).toMatchAttribute("href", url)
       await expect(anchor).toMatchAttribute("href", /\.com$/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       const anchor = await page.$("a")
       await assertSnapshot(() =>
         expect(anchor).toMatchAttribute("href", longUrl)
@@ -60,23 +61,23 @@ describe("toMatchAttribute", () => {
 
   describe("with 'not' usage", () => {
     it("positive", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       await expect(page).not.toMatchAttribute("a", "href", longUrl)
       await expect(page).not.toMatchAttribute("a", "href", longUrl)
     })
 
     it("positive in frame", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<iframe src="http://example.com">')
       const handle = await page.$("iframe")
       const frame = handle?.contentFrame()
-      await expect(handle).not.toMatchAttribute("a", "href", longUrl)
-      await expect(frame).not.toMatchAttribute("a", "href", /\.org$/)
+      await expect(handle).not.toMatchAttribute("a", "href", "foo")
+      await expect(frame).not.toMatchAttribute("a", "href", /foo/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">Hi</a>')
+      await page.setContent('<a href="https://google.com">Hi</a>')
       await assertSnapshot(() =>
-        expect(page).not.toMatchAttribute("a", "href", "http://google.com")
+        expect(page).not.toMatchAttribute("a", "href", url)
       )
     })
   })

--- a/src/matchers/toMatchAttribute/index.test.ts
+++ b/src/matchers/toMatchAttribute/index.test.ts
@@ -1,18 +1,33 @@
 import { assertSnapshot } from "../tests/utils"
 
+const url = "https://google.com"
+const longUrl = "https://www.google.com"
+
 describe("toMatchAttribute", () => {
   afterEach(() => page.setContent(""))
 
   describe("selector", () => {
     it("positive", async () => {
       await page.setContent('<a href="http://google.com">Hi</a>')
-      await expect(page).toMatchAttribute("a", "href", "http://google.com")
+      await expect(page).toMatchAttribute("a", "href", url)
+      await expect(page).toMatchAttribute("a", "href", /\.com$/)
+    })
+
+    it("positive in frame", async () => {
+      await page.setContent('<a href="http://google.com">Hi</a>')
+      const handle = await page.$("iframe")
+      const frame = handle?.contentFrame()
+      await expect(handle).toMatchAttribute("a", "href", url)
+      await expect(frame).toMatchAttribute("a", "href", /\.com$/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await page.setContent('<a href="http://google.com">Hi</a>')
       await assertSnapshot(() =>
-        expect(page).toMatchAttribute("a", "href", "https://www.google.com")
+        expect(page).toMatchAttribute("a", "href", longUrl)
+      )
+      await assertSnapshot(() =>
+        expect(page).toMatchAttribute("a", "href", /\.org$/)
       )
     })
 
@@ -25,32 +40,41 @@ describe("toMatchAttribute", () => {
 
   describe("element", () => {
     it("positive", async () => {
-      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await page.setContent('<a href="http://google.com">Hi</a>')
       const anchor = await page.$("a")
       await expect(anchor).toMatchAttribute("href", "http://google.com")
+      await expect(anchor).toMatchAttribute("href", /\.com$/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await page.setContent('<a href="http://google.com">Hi</a>')
       const anchor = await page.$("a")
       await assertSnapshot(() =>
-        expect(anchor).toMatchAttribute("href", "https://www.google.com")
+        expect(anchor).toMatchAttribute("href", longUrl)
+      )
+      await assertSnapshot(() =>
+        expect(anchor).toMatchAttribute("href", /\.org$/)
       )
     })
   })
 
   describe("with 'not' usage", () => {
     it("positive", async () => {
-      await page.setContent('<a href="http://google.com">>Hi</a>')
-      await expect(page).not.toMatchAttribute(
-        "a",
-        "href",
-        "https://www.google.com"
-      )
+      await page.setContent('<a href="http://google.com">Hi</a>')
+      await expect(page).not.toMatchAttribute("a", "href", longUrl)
+      await expect(page).not.toMatchAttribute("a", "href", longUrl)
+    })
+
+    it("positive in frame", async () => {
+      await page.setContent('<a href="http://google.com">Hi</a>')
+      const handle = await page.$("iframe")
+      const frame = handle?.contentFrame()
+      await expect(handle).not.toMatchAttribute("a", "href", longUrl)
+      await expect(frame).not.toMatchAttribute("a", "href", /\.org$/)
     })
 
     it("negative", async () => {
-      await page.setContent('<a href="http://google.com">>Hi</a>')
+      await page.setContent('<a href="http://google.com">Hi</a>')
       await assertSnapshot(() =>
         expect(page).not.toMatchAttribute("a", "href", "http://google.com")
       )

--- a/src/matchers/toMatchAttribute/index.ts
+++ b/src/matchers/toMatchAttribute/index.ts
@@ -1,5 +1,10 @@
 import { SyncExpectationResult } from "expect/build/types"
-import { getElementHandle, getMessage, InputArguments } from "../utils"
+import {
+  compareText,
+  getElementHandle,
+  getMessage,
+  InputArguments,
+} from "../utils"
 
 const toMatchAttribute: jest.CustomMatcher = async function (
   ...args: InputArguments
@@ -12,7 +17,7 @@ const toMatchAttribute: jest.CustomMatcher = async function (
     const actualValue = await elementHandle.getAttribute(attribute)
 
     return {
-      pass: expectedValue === actualValue,
+      pass: compareText(expectedValue, actualValue),
       message: () =>
         getMessage(this, "toMatchAttribute", expectedValue, actualValue),
     }

--- a/src/matchers/toMatchAttribute/index.ts
+++ b/src/matchers/toMatchAttribute/index.ts
@@ -19,7 +19,13 @@ const toMatchAttribute: jest.CustomMatcher = async function (
     return {
       pass: compareText(expectedValue, actualValue),
       message: () =>
-        getMessage(this, "toMatchAttribute", expectedValue, actualValue),
+        getMessage(
+          this,
+          "toMatchAttribute",
+          expectedValue,
+          actualValue,
+          `"${attribute}", expected`
+        ),
     }
   } catch (err) {
     return {

--- a/src/matchers/toMatchAttribute/index.ts
+++ b/src/matchers/toMatchAttribute/index.ts
@@ -1,0 +1,27 @@
+import { SyncExpectationResult } from "expect/build/types"
+import { getElementHandle, getMessage, InputArguments } from "../utils"
+
+const toMatchAttribute: jest.CustomMatcher = async function (
+  ...args: InputArguments
+): Promise<SyncExpectationResult> {
+  try {
+    const [elementHandle, [attribute, expectedValue]] = await getElementHandle(
+      args,
+      2
+    )
+    const actualValue = await elementHandle.getAttribute(attribute)
+
+    return {
+      pass: expectedValue === actualValue,
+      message: () =>
+        getMessage(this, "toMatchAttribute", expectedValue, actualValue),
+    }
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => err.toString(),
+    }
+  }
+}
+
+export default toMatchAttribute

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -62,7 +62,8 @@ export const getMessage = (
   { isNot, promise, utils, expand }: jest.MatcherContext,
   matcher: string,
   expected: unknown,
-  received: unknown
+  received: unknown,
+  expectedHint: string | undefined = undefined
 ) => {
   const message = isNot
     ? `Expected: not ${utils.printExpected(expected)}`
@@ -75,7 +76,7 @@ export const getMessage = (
       )
 
   return (
-    utils.matcherHint(matcher, undefined, undefined, { isNot, promise }) +
+    utils.matcherHint(matcher, undefined, expectedHint, { isNot, promise }) +
     "\n\n" +
     message
   )


### PR DESCRIPTION
Adds a new matcher `toMatchAttribute` which allows checking if an element has a given attribute.  Allows text or regex matching.

<img width="719" alt="Screen Shot 2021-06-27 at 8 12 44 AM" src="https://user-images.githubusercontent.com/25914066/123545771-79104700-d71f-11eb-813d-93913659f9ba.png">
