### PR TITLE
Allow passing an unresolved promise to matchers

### DIFF
--- a/src/matchers/toBeChecked/index.test.ts
+++ b/src/matchers/toBeChecked/index.test.ts
@@ -34,8 +34,9 @@ describe("toBeChecked", () => {
   describe("element", () => {
     it("positive", async () => {
       await page.setContent('<input type="radio" checked>')
-      const input = await page.$("input")
+      const input = page.$("input")
       await expect(input).toBeChecked()
+      await expect(await input).toBeChecked()
     })
 
     it("negative: target element isn't checked", async () => {

--- a/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeDisabled/__snapshots__/index.test.ts.snap
@@ -1,13 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toBeDisabled negative: target element isn't enabled 1`] = `
+exports[`toBeDisabled element negative: target element isn't enabled 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoBeDisabled[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
 `;
 
-exports[`toBeDisabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
+exports[`toBeDisabled selector negative: target element isn't enabled 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeDisabled[2m()[22m
+
+Expected: [32mtrue[39m
+Received: [31mfalse[39m"
+`;
+
+exports[`toBeDisabled selector negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
 
 exports[`toBeDisabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
 

--- a/src/matchers/toBeDisabled/index.test.ts
+++ b/src/matchers/toBeDisabled/index.test.ts
@@ -5,21 +5,38 @@ describe("toBeDisabled", () => {
     await page.setContent("")
   })
 
-  it("positive", async () => {
-    await page.setContent('<button id="foo" disabled>')
-    await expect(page).toBeDisabled("#foo")
+  describe("selector", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      await expect(page).toBeDisabled("#foo")
+    })
+
+    it("negative: target element isn't enabled", async () => {
+      await page.setContent('<button id="foo">')
+      await assertSnapshot(() => expect(page).toBeDisabled("#foo"))
+    })
+
+    it("negative: target element not found", async () => {
+      await page.setContent('<button id="foo">')
+      await assertSnapshot(() =>
+        expect(page).toBeDisabled("#bar", { timeout: 1000 })
+      )
+    })
   })
 
-  it("negative: target element isn't enabled", async () => {
-    await page.setContent('<button id="foo">')
-    await assertSnapshot(() => expect(page).toBeDisabled("#foo"))
-  })
+  describe("element", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      const button = page.$("#foo")
+      await expect(button).toBeDisabled()
+      await expect(await button).toBeDisabled()
+    })
 
-  it("negative: target element not found", async () => {
-    await page.setContent('<button id="foo">')
-    await assertSnapshot(() =>
-      expect(page).toBeDisabled("#bar", { timeout: 1000 })
-    )
+    it("negative: target element isn't enabled", async () => {
+      await page.setContent('<button id="foo">')
+      const button = await page.$("#foo")
+      await assertSnapshot(() => expect(button).toBeDisabled())
+    })
   })
 
   describe("with 'not' usage", () => {

--- a/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
+++ b/src/matchers/toBeEnabled/__snapshots__/index.test.ts.snap
@@ -1,13 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toBeEnabled negative: target element isn't enabled 1`] = `
+exports[`toBeEnabled element negative: target element isn't enabled 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m()[22m
 
 Expected: [32mtrue[39m
 Received: [31mfalse[39m"
 `;
 
-exports[`toBeEnabled negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
+exports[`toBeEnabled selector negative: target element isn't enabled 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).[22mtoBeEnabled[2m()[22m
+
+Expected: [32mtrue[39m
+Received: [31mfalse[39m"
+`;
+
+exports[`toBeEnabled selector negative: target element not found 1`] = `"Error: Timeout exceed for element '#bar'"`;
 
 exports[`toBeEnabled timeout should throw an error after the timeout exceeds 1`] = `"Error: Timeout exceed for element '#foo'"`;
 

--- a/src/matchers/toBeEnabled/index.test.ts
+++ b/src/matchers/toBeEnabled/index.test.ts
@@ -5,21 +5,38 @@ describe("toBeEnabled", () => {
     await page.setContent("")
   })
 
-  it("positive", async () => {
-    await page.setContent('<button id="foo">')
-    await expect(page).toBeEnabled("#foo")
+  describe("selector", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo">')
+      await expect(page).toBeEnabled("#foo")
+    })
+
+    it("negative: target element isn't enabled", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      await assertSnapshot(() => expect(page).toBeEnabled("#foo"))
+    })
+
+    it("negative: target element not found", async () => {
+      await page.setContent('<button id="foo">')
+      await assertSnapshot(() =>
+        expect(page).toBeEnabled("#bar", { timeout: 1000 })
+      )
+    })
   })
 
-  it("negative: target element isn't enabled", async () => {
-    await page.setContent('<button id="foo" disabled>')
-    await assertSnapshot(() => expect(page).toBeEnabled("#foo"))
-  })
+  describe("element", () => {
+    it("positive", async () => {
+      await page.setContent('<button id="foo">')
+      const button = page.$("#foo")
+      await expect(button).toBeEnabled()
+      await expect(await button).toBeEnabled()
+    })
 
-  it("negative: target element not found", async () => {
-    await page.setContent('<button id="foo">')
-    await assertSnapshot(() =>
-      expect(page).toBeEnabled("#bar", { timeout: 1000 })
-    )
+    it("negative: target element isn't enabled", async () => {
+      await page.setContent('<button id="foo" disabled>')
+      const button = await page.$("#foo")
+      await assertSnapshot(() => expect(button).toBeEnabled())
+    })
   })
 
   describe("with 'not' usage", () => {

--- a/src/matchers/toEqualValue/index.test.ts
+++ b/src/matchers/toEqualValue/index.test.ts
@@ -34,8 +34,9 @@ describe("toEqualValue", () => {
   describe("element", () => {
     it("positive", async () => {
       await page.setContent(`<input id="foobar" value="bar"/>`)
-      const element = await page.$("#foobar")
+      const element = page.$("#foobar")
       await expect(element).toEqualValue("bar")
+      await expect(await element).toEqualValue("bar")
     })
 
     it("negative", async () => {

--- a/src/matchers/toMatchAttribute/index.test.ts
+++ b/src/matchers/toMatchAttribute/index.test.ts
@@ -42,9 +42,9 @@ describe("toMatchAttribute", () => {
   describe("element", () => {
     it("positive", async () => {
       await page.setContent('<a href="https://google.com">Hi</a>')
-      const anchor = await page.$("a")
+      const anchor = page.$("a")
       await expect(anchor).toMatchAttribute("href", url)
-      await expect(anchor).toMatchAttribute("href", /\.com$/)
+      await expect(await anchor).toMatchAttribute("href", /\.com$/)
     })
 
     it("negative", async () => {

--- a/src/matchers/toMatchText/index.test.ts
+++ b/src/matchers/toMatchText/index.test.ts
@@ -77,15 +77,9 @@ describe("toMatchText", () => {
   describe("element", () => {
     it("positive", async () => {
       await page.setContent(`<div id="foobar">Bar</div>`)
-      const element = await page.$("#foobar")
-      expect(element).not.toBeNull()
-      await expect(element!).toMatchText(/Bar/)
-    })
-    it("positive with string", async () => {
-      await page.setContent(`<div id="foobar">Bar</div>`)
-      const element = await page.$("#foobar")
-      expect(element).not.toBeNull()
-      await expect(element!).toMatchText("Bar")
+      const element = page.$("#foobar")
+      await expect(element).toMatchText("Bar")
+      await expect(await element).toMatchText(/Bar/)
     })
     it("negative", async () => {
       await page.setContent(`<div id="foobar">zzzBarzzz</div>`)

--- a/src/matchers/toMatchTitle/index.test.ts
+++ b/src/matchers/toMatchTitle/index.test.ts
@@ -53,9 +53,13 @@ describe("toMatchTitle", () => {
 
   it("should work in frames", async () => {
     await page.setContent('<iframe src="https://example.com"></iframe>')
-    const handle = await page.$("iframe")
-    const iframe = await handle?.contentFrame()
+
+    const handle = page.$("iframe")
     await expect(handle).toMatchTitle("Example Domain")
+    await expect(await handle).toMatchTitle("Example Domain")
+
+    const iframe = (await handle)?.contentFrame()
     await expect(iframe).toMatchTitle(/example domain/i)
+    await expect(await iframe).toMatchTitle(/example domain/i)
   })
 })

--- a/src/matchers/toMatchURL/index.test.ts
+++ b/src/matchers/toMatchURL/index.test.ts
@@ -21,10 +21,14 @@ describe("toMatchURL", () => {
   it("positive in frame", async () => {
     const myUrl = `${urlPrefix}/1.html`
     await page.setContent(`<iframe src="${myUrl}"></iframe>`)
-    const handle = await page.$("iframe")
-    const iframe = await handle?.contentFrame()
+
+    const handle = page.$("iframe")
     await expect(handle).toMatchURL(myUrl)
+    await expect(await handle).toMatchURL(myUrl)
+
+    const iframe = (await handle)?.contentFrame()
     await expect(iframe).toMatchURL(/\d\.html$/)
+    await expect(await iframe).toMatchURL(/\d\.html$/)
   })
 
   it("positive", async () => {
@@ -43,10 +47,14 @@ describe("toMatchURL", () => {
     it("positive in frame", async () => {
       const myUrl = `${urlPrefix}/1.html`
       await page.setContent(`<iframe src="${myUrl}"></iframe>`)
-      const handle = await page.$("iframe")
-      const iframe = await handle?.contentFrame()
+
+      const handle = page.$("iframe")
       await expect(handle).not.toMatchURL("foobar")
+      await expect(await handle).not.toMatchURL("foobar")
+
+      const iframe = (await handle)?.contentFrame()
       await expect(iframe).not.toMatchURL(/foo/)
+      await expect(await iframe).not.toMatchURL(/foo/)
     })
 
     it("positive", async () => {

--- a/src/matchers/toMatchValue/index.test.ts
+++ b/src/matchers/toMatchValue/index.test.ts
@@ -60,9 +60,9 @@ describe("toMatchValue", () => {
   describe("element", () => {
     it("positive", async () => {
       await page.setContent(`<input id="foobar" value="bar"/>`)
-      const element = await page.$("#foobar")
+      const element = page.$("#foobar")
       await expect(element).toMatchValue("bar")
-      await expect(element).toMatchValue(/ba/)
+      await expect(await element).toMatchValue(/ba/)
     })
 
     it("negative", async () => {


### PR DESCRIPTION
Fixes #106 

This allows all matchers to accept a promise as an argument to expect to make it easier if using an element handle.

### Before

```js
await expect(await page.$('button')).toBeEnabled()
```

### After

```js
await expect(page.$('button')).toBeEnabled()
```