### PR TITLE
Support locators

### DIFF
--- a/src/matchers/toBeChecked/index.test.ts
+++ b/src/matchers/toBeChecked/index.test.ts
@@ -46,6 +46,14 @@ describe("toBeChecked", () => {
     })
   })
 
+  describe("locator", () => {
+    it("positive", async () => {
+      await page.setContent('<input type="radio" checked>')
+      const input = page.locator("input")
+      await expect(input).toBeChecked()
+    })
+  })
+
   describe("with 'not' usage", () => {
     it("positive", async () => {
       await page.setContent('<input type="checkbox">')

--- a/src/matchers/toBeChecked/index.test.ts
+++ b/src/matchers/toBeChecked/index.test.ts
@@ -49,8 +49,12 @@ describe("toBeChecked", () => {
   describe("locator", () => {
     it("positive", async () => {
       await page.setContent('<input type="radio" checked>')
-      const input = page.locator("input")
-      await expect(input).toBeChecked()
+      await expect(page.locator("input")).toBeChecked()
+    })
+
+    it("positive", async () => {
+      await page.setContent('<input type="radio">')
+      await expect(page.locator("input")).not.toBeChecked()
     })
   })
 

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -1,11 +1,15 @@
-import type { Page, ElementHandle, Frame } from "playwright-core"
+import type { Page, ElementHandle, Frame, Locator } from "playwright-core"
 import { PageWaitForSelectorOptions } from "../../global"
 
-type Handle = Page | Frame | ElementHandle
+type Handle = Page | Frame | ElementHandle | Locator
 export type ExpectInputType = Handle | Promise<Handle>
 
 const isElementHandle = (value: Handle): value is ElementHandle => {
   return value.constructor.name === "ElementHandle"
+}
+
+const isLocator = (value: Handle): value is Locator => {
+  return value.constructor.name === "Locator"
 }
 
 export const getFrame = async (value: ExpectInputType) => {
@@ -42,7 +46,7 @@ export const getElementHandle = async (
 
   // If the user provided a page or iframe, we need to locate the provided
   // selector or the `body` element if none was provided.
-  if (!isElementHandle(elementHandle)) {
+  if (!isElementHandle(elementHandle) && !isLocator(elementHandle)) {
     const selector = args[1] ?? "body"
 
     try {

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -41,22 +41,25 @@ export const getElementHandle = async (
   const expectedValue = args.splice(-valueArgCount, valueArgCount) as string[]
 
   // Finally, we can find the element handle
-  const handle = await args[0]
-  let elementHandle = (await getFrame(handle)) ?? handle
+  let handle = await args[0]
+  handle = (await getFrame(handle)) ?? handle
 
+  if (isLocator(handle)) {
+    handle = (await handle.elementHandle())!
+  }
   // If the user provided a page or iframe, we need to locate the provided
   // selector or the `body` element if none was provided.
-  if (!isElementHandle(elementHandle) && !isLocator(elementHandle)) {
+  else if (!isElementHandle(handle)) {
     const selector = args[1] ?? "body"
 
     try {
-      elementHandle = (await elementHandle.waitForSelector(selector, options))!
+      handle = (await handle.waitForSelector(selector, options))!
     } catch (err) {
       throw new Error(`Timeout exceed for element ${quote(selector)}`)
     }
   }
 
-  return [elementHandle, expectedValue] as const
+  return [handle, expectedValue] as const
 }
 
 export const quote = (val: string | null) => (val === null ? "" : `'${val}'`)

--- a/src/matchers/utils.ts
+++ b/src/matchers/utils.ts
@@ -14,7 +14,10 @@ const isLocator = (value: Handle): value is Locator => {
 
 export const getFrame = async (value: ExpectInputType) => {
   const resolved = await value
-  return isElementHandle(resolved) ? resolved.contentFrame() : resolved
+
+  return isElementHandle(resolved)
+    ? resolved.contentFrame()
+    : (resolved as Page | Frame)
 }
 
 const isObject = (value: unknown) =>


### PR DESCRIPTION
Even though `@playwright/test` is the recommend approach moving forward, supporting locators in expect-playwright should help the migration path by allowing people to update their page objects to use locators before making the full switch to `@playwright/test`.